### PR TITLE
Remove unaccessible folders in sftp plugin

### DIFF
--- a/src/service/plugins/sftp.js
+++ b/src/service/plugins/sftp.js
@@ -156,11 +156,11 @@ var Plugin = new Lang.Class({
 
         // Set the directories and notify (client.js needs this before mounted)
         for (let index in packet.body.pathNames) {
-            let name = packet.body.pathNames[index];
-            let path = packet.body.multiPaths[index].replace(packet.body.path, "");
-            path = path.replace(packet.body.path, "");
-
-            this._directories[name] = this._path + path;
+            if ( packet.body.multiPaths[index].search(packet.body.path) === 0 ) {
+                let name = packet.body.pathNames[index];
+                let path = packet.body.multiPaths[index].replace(packet.body.path, "");
+                this._directories[name] = this._path + path;
+            }
         }
 
         this.notify("directories");


### PR DESCRIPTION
On my phone, the path is `/storage/emulated/0/`, this is for the internal memory. The SD card is at `/storage/XXXX-XXXX/`, so it is not accessible by sftp. I would say it is a bug in the Android client, but in the meantime, better not to display the sdcard (any not accessible folder in fact) in the plugin list.

See https://github.com/Bajoja/indicator-kdeconnect/issues/66 and https://bugs.kde.org/show_bug.cgi?id=336043