### PR TITLE
Update Metadata: Add GNOME 3.28 Support

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -4,6 +4,6 @@
 "name": "GSConnect",
 "description": "KDE Connect implementation with Gnome Shell integration",
 "version": "@VERSION@",
-"shell-version": [ "3.24", "3.26" ],
+"shell-version": [ "3.24", "3.26", "3.28" ],
 "url": "https://github.com/andyholmes/gnome-shell-extension-gsconnect/wiki"
 }


### PR DESCRIPTION
Tested on GNOME 3.28