### PR TITLE
Allow tel: URIs to be shared

### DIFF
--- a/src/service/plugins/share.js
+++ b/src/service/plugins/share.js
@@ -417,7 +417,7 @@ var Plugin = new Lang.Class({
 
             channel.open();
         } else {
-            if (!uri.startsWith("http://") && !uri.startsWith("https://")) {
+            if (!uri.startsWith("http://") && !uri.startsWith("https://") && !uri.startsWith("tel:")) {
                 uri = "https://" + uri;
             }
 


### PR DESCRIPTION
This allows `tel:` URIs to be passed to a phone from the Share File/URL dialog.  This is a first step towards allowing `tel:` URIs clicked in a browser to be passed directly to the phone.