### PR TITLE
Fix gnome 3.30 yield keyword issue

### DIFF
--- a/src/service/plugins/telephony.js
+++ b/src/service/plugins/telephony.js
@@ -910,7 +910,7 @@ var ContactsCache = new Lang.Class({
     },
 
     /** Get all google accounts in Goa */
-    _getGoogleAccounts: function () {
+    _getGoogleAccounts: function* () {
         let goaClient = Goa.Client.new_sync(null);
         let goaAccounts = goaClient.get_accounts();
 


### PR DESCRIPTION
Fixes an issue on my machine:

```
Sep 12 22:22:02 gjs[1756]: JS ERROR: SyntaxError: yield is a reserved identifier @ /home/x/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/plugins/telephony.js:921
Sep 12 22:22:02 org.gnome.Shell.Extensions.GSConnect[823]: Script /home/x/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/daemon.js threw an exception
Sep 12 22:22:02 dbus-daemon[823]: [session uid=1000 pid=823] Activated service 'org.gnome.Shell.Extensions.GSConnect' failed: Process org.gnome.Shell.Extensions.GSConnect exited with status 1
```