### PR TITLE
Fix removal of widget property

### DIFF
--- a/src/widgets/preferences.js
+++ b/src/widgets/preferences.js
@@ -482,8 +482,7 @@ var Setting = new Lang.Class({
             this.grid.attach(this.description, 0, 1, 1, 1);
         }
 
-        this.widget = widget;
-        this.grid.attach(this.widget, 1, 0, 1, (description) ? 2 : 1);
+        this.grid.attach(widget, 1, 0, 1, (description) ? 2 : 1);
     }
 });
 


### PR DESCRIPTION
Fixes "no property widget" error when opening preferences in Gnome 3.30.  Hopefully there are no side effects...