### PR TITLE
meson: Add post-install script

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -170,3 +170,8 @@ gnome.compile_resources(
 # Gettext Translations
 subdir('po')
 
+meson.add_install_script(
+  find_program('env').path(),
+  'GSCHEMADIR=' + gschemadir,
+  join_paths(meson.source_root(), 'meson/post-install.sh')
+)

--- a/meson/mkzip.sh
+++ b/meson/mkzip.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 ZIP_DESTDIR="${MESON_BUILD_ROOT}/_zip"
 ZIP_DIR="${MESON_BUILD_ROOT}/${UUID}"

--- a/meson/post-install.sh
+++ b/meson/post-install.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+GSCHEMA_DIR="${DESTDIR}/${GSCHEMADIR}"
+
+glib-compile-schemas "${GSCHEMA_DIR}"


### PR DESCRIPTION
In some cases, distro hooks do not apply, so we need to compile schemas manually.