### PR TITLE
Fix visibility of plugin settings

### DIFF
--- a/src/service/ui/settings.js
+++ b/src/service/ui/settings.js
@@ -1261,7 +1261,7 @@ var Device = GObject.registerClass({
             this.settings.set_strv('disabled-plugins', disabled);
 
             if (this.hasOwnProperty(name)) {
-                this[name].visible = disabled.includes(name);
+                this[name].visible = !disabled.includes(name);
             }
         } catch (e) {
             logError(e);


### PR DESCRIPTION
Invert the logic for plugin-settings visibility, as described by @andyholmes in #258.

Fixes: #258