### PR TITLE
Update PackageKit req's for nautilus

### DIFF
--- a/src/service/ui/packagekit.js
+++ b/src/service/ui/packagekit.js
@@ -53,8 +53,10 @@ const PackageGroup = {
     // Feature:     Files Integration
     // Requires:    `Nautilus-3.0.typelib`, `libnautilus-python.so`
     'nautilus': [
-        // Fedora, Gentoo
-        'nautilus-python', 'nautilus-extensions', 'python2-gobject',
+        // Fedora
+        'python2-nautilus', 'nautilus-extensions', 'python2-gobject',
+        // Gentoo
+        'nautilus-python', 'pygobject',
         // Arch, Debian/Ubuntu, openSUSE
         'python-nautilus', 'gir1.2-nautilus-3.0'
     ],
@@ -356,4 +358,3 @@ var DependencyButton = GObject.registerClass({
         }
     }
 });
-


### PR DESCRIPTION
I already updated the wiki, but figured I'd submit the source change as well:

* Fedora doesn't even have a `nautilus-python`, that's provided by `python2-nautilus`.
* Gentoo doesn't appear to have a `nautilus-extensions`, seems that's Fedora-only.
* (Also, it _seems_ like [Gentoo's package is called `pygobject`][1], not `python2-gobject`, so I also added that just in case.)

[1]: https://packages.gentoo.org/packages/dev-python/pygobject