### PR TITLE
Rework PackageKit dependency management

### DIFF
--- a/src/service/ui/packagekit.js
+++ b/src/service/ui/packagekit.js
@@ -265,8 +265,6 @@ var DependencyButton = GObject.registerClass({
     }
 
     _done(icon_name=null) {
-        this._button.get_style_context().remove_class('suggested-action');
-
         this._button.visible = false;
         this._spinner.visible = false;
 
@@ -276,8 +274,6 @@ var DependencyButton = GObject.registerClass({
     }
 
     _warning(e) {
-        this._button.get_style_context().remove_class('suggested-action');
-
         this._result.visible = false;
         this._spinner.visible = false;
 
@@ -294,7 +290,6 @@ var DependencyButton = GObject.registerClass({
 
         this._button.visible = true;
         this._button.image.icon_name = 'folder-download-symbolic';
-        this._button.get_style_context().add_class('suggested-action');
         this.tooltip_markup = this._packages.map(pkg => {
             return `<b>${pkg.get_name()}</b> - ${pkg.get_summary()}`
         }).join('\n');

--- a/src/service/ui/packagekit.js
+++ b/src/service/ui/packagekit.js
@@ -303,9 +303,11 @@ var DependencyButton = GObject.registerClass({
                 return;
             }
 
-            // Reduce the possible packages to the names of those available
-            available = await this._query(this.names, 'arch;newest');
-            available = available.map(pkg => pkg.get_name());
+            // Filter the package names into what's available and what's installed
+            let available = await this._query(this.names, 'arch;newest');
+            let installed = await this._query(available.map(pkg => pkg.get_name()),
+                                              'arch;newest;installed');
+            installed = installed.map(pkg => pkg.get_name());
 
             // No available packages
             if (available.length === 0) {
@@ -313,8 +315,8 @@ var DependencyButton = GObject.registerClass({
                 return;
             }
 
-            // Reduce the available packages to those that are uninstalled
-            installable = await this._query(available, 'arch;newest;~installed');
+            // If any available names are not installed, we can install them on demand
+            let installable = available.filter(pkg => !installed.includes(pkg.get_name()));
 
             // All available packages are installed
             if (installable.length === 0) {


### PR DESCRIPTION
* Remove the install buttons' `suggested-action` styling
* Refactor `_getInstallable()` / `_getAvailable()` into `_query(names, filter)`
* Update the installed-packages discovery logic, as outlined [in this comment](https://github.com/andyholmes/gnome-shell-extension-gsconnect/issues/263#issuecomment-433662336).

Fixes #263, fixes #273 