### PR TITLE
Settings: Update add-on/app links

### DIFF
--- a/data/settings.ui
+++ b/data/settings.ui
@@ -5,7 +5,7 @@
   <template class="GSConnectSettingsWindow" parent="GtkApplicationWindow">
     <property name="can_focus">False</property>
     <property name="default_width">640</property>
-    <property name="default_height">440</property>
+    <property name="default_height">580</property>
     <child type="titlebar">
       <object class="GtkHeaderBar" id="headerbar">
         <property name="visible">True</property>
@@ -845,7 +845,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
-                            <property name="top_attach">2</property>
+                            <property name="top_attach">3</property>
                           </packing>
                         </child>
                         <child>
@@ -873,66 +873,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
-                            <property name="top_attach">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkGrid">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="column_spacing">12</property>
-                            <child>
-                              <object class="GtkLinkButton">
-                                <property name="label" translatable="yes">Android</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="halign">start</property>
-                                <property name="relief">none</property>
-                                <property name="uri">https://play.google.com/store/apps/details?id=org.kde.kdeconnect_tp</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="top_attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLinkButton">
-                                <property name="label" translatable="yes">Sailfish OS</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="halign">start</property>
-                                <property name="relief">none</property>
-                                <property name="uri">https://openrepos.net/content/piggz/kde-connect</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">2</property>
-                                <property name="top_attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="height_request">32</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="valign">center</property>
-                                <property name="label" translatable="yes">KDE Connect</property>
-                                <attributes>
-                                  <attribute name="weight" value="bold"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="left_attach">0</property>
-                                <property name="top_attach">0</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
                             <property name="top_attach">3</property>
-                            <property name="width">2</property>
                           </packing>
                         </child>
                         <child>
@@ -949,6 +890,60 @@
                           <packing>
                             <property name="left_attach">1</property>
                             <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="valign">center</property>
+                            <property name="margin_bottom">8</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Browser Add-Ons</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="valign">center</property>
+                            <property name="margin_bottom">8</property>
+                            <property name="label" translatable="yes">KDE Connect</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">4</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="valign">baseline</property>
+                            <property name="margin_bottom">8</property>
+                            <property name="label" translatable="yes">Android (&lt;a href="https://play.google.com/store/apps/details?id=org.kde.kdeconnect_tp"&gt;Play Store&lt;/a&gt; / &lt;a href="https://f-droid.org/packages/org.kde.kdeconnect_tp/"&gt;F-Droid&lt;/a&gt;), &lt;a href="https://openrepos.net/content/piggz/kde-connect"&gt;Sailfish OS&lt;/a&gt;</property>
+                            <property name="use_markup">True</property>
+                            <property name="track_visited_links">False</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">5</property>
+                            <property name="width">2</property>
                           </packing>
                         </child>
                       </object>


### PR DESCRIPTION
Taking @rugk's points in #268 to heart, I added a link to F-Droid as an app source, alongside Play Store. While I was in there I did a bit of a refresh:
* Added a "Browser Add-Ons" heading over the store buttons
* Changed "KDE Connect" to a heading
* Replaced the `GtkLinkButton` links with a single `GtkLabel` that uses Pango markup to create the hyperlinks
* Changed "Android" link to "Play Store"
* Added "F-Droid" link as an alternative Android source
* Increased default height to `580px`, to accomodate

The window now looks like this:

![image](https://user-images.githubusercontent.com/538020/47682271-42ff1b80-dba2-11e8-8396-2a793974f10a.png)

The markup has one down side, which is that the translatable string includes that markup. The _escaped_ markup. The string that translators will receive is, in full:
```html
Android (&lt;a href="https://play.google.com/store/apps/details?id=org.kde.kdeconnect_tp"&gt;
Play Store&lt;/a&gt; / &lt;a href="https://f-droid.org/packages/org.kde.kdeconnect_tp/"&gt;
F-Droid&lt;/a&gt;), &lt;a href="https://openrepos.net/content/piggz/kde-connect"&gt;
Sailfish OS&lt;/a&gt;
```

If that's a problem (too ugly for translators), an [oft-suggested alternative](https://stackoverflow.com/questions/4640084/django-templates-best-practice-for-translating-text-block-with-html-in-it) is to construct the label from a placeholder-laced string instead, via `.format()`. (This would involve moving the label text into the JavaScript source.) So, e.g.:
```js
widget.set_label(_('Android (%sPlay Store%s, %sF-Droid%s), %sSailfish OS%s').format(...));
```
However, this will break if the order of the HTML fragments changes, which I have to believe it would when dealing with translations in RTL languages. It'd be better if more expressive placeholder strings could be used.
```js
// i.e.
_('Android ({play-link}Play Store{lend}, {fdroid-link}F-Droid{lend}...').format(...);
// or even...
_('Android ({0}Play Store</a>, {1}F-Droid</a>), {2}Sailfish OS</a>').format(...)
```
 I don't know the translation system in use, is that possible?

(With all due respect to @rugk, I think using app-link _buttons_ would be overkill, and a waste of screen real estate because **nobody** will actually be using these — they'll search for "KDE Connect" in their device's applications directory, where they should be getting the app.)