### PR TITLE
Sound Component: refactor libcanberra/gsound checks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,124 @@
+{
+    "env": {
+        "es6": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "array-bracket-newline": [
+            "error",
+            "consistent"
+        ],
+        "array-bracket-spacing": [
+            "error",
+            "never"
+        ],
+        "brace-style": "error",
+        "comma-spacing": [
+            "error",
+            {
+                "before": false,
+                "after": true
+            }
+        ],
+        "indent": [
+            "error",
+            4,
+            {
+                "MemberExpression": "off"
+            }
+        ],
+        "key-spacing": [
+            "error",
+            {
+                "beforeColon": false,
+                "afterColon": true
+            }
+        ],
+        "keyword-spacing": [
+            "error",
+            {
+                "before": true,
+                "after": true
+            }
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "no-empty": [
+            "error",
+            {
+                "allowEmptyCatch": true
+            }
+        ],
+        "no-implicit-coercion": [
+            "error",
+            {
+                "allow": ["!!"]
+            }
+        ],
+        "nonblock-statement-body-position": [
+            "error",
+            "below"
+        ],
+        "object-curly-newline": [
+            "error",
+            {
+                "consistent": true
+            }
+        ],
+        "object-curly-spacing": "error",
+        "prefer-template": "error",
+        "quotes": [
+            "error",
+            "single",
+            {
+                "avoidEscape": true
+            }
+        ],
+        "semi": [
+            "error",
+            "always"
+        ],
+        "semi-spacing": [
+            "error",
+            {
+                "before": false,
+                "after": true
+            }
+        ],
+        "space-before-blocks": "error",
+        "space-infix-ops": [
+            "error",
+            {
+                "int32Hint": false
+            }
+        ]
+    },
+    "globals": {
+        "ARGV": false,
+        "Debugger": false,
+        "GIRepositoryGType": false,
+        "imports": false,
+        "Intl": false,
+        "log": false,
+        "logError": false,
+        "print": false,
+        "printerr": false,
+        "window": false,
+
+        "gsconnect": false,
+        "debug": false,
+        "logWarning": false,
+        "_": false,
+        "_C": false,
+        "_N": false,
+        "ngettext": false,
+        "play_theme_sound": false,
+        "loop_theme_sound": false
+    },
+    "parserOptions": {
+        "ecmaVersion": 2017
+    }
+}
+

--- a/data/settings.ui
+++ b/data/settings.ui
@@ -936,7 +936,7 @@
                             <property name="halign">start</property>
                             <property name="valign">baseline</property>
                             <property name="margin_bottom">8</property>
-                            <property name="label" translatable="yes">Android (&lt;a href="https://play.google.com/store/apps/details?id=org.kde.kdeconnect_tp"&gt;Play Store&lt;/a&gt; / &lt;a href="https://f-droid.org/packages/org.kde.kdeconnect_tp/"&gt;F-Droid&lt;/a&gt;), &lt;a href="https://openrepos.net/content/piggz/kde-connect"&gt;Sailfish OS&lt;/a&gt;</property>
+                            <property name="label" translatable="no">Android (&lt;a href="https://play.google.com/store/apps/details?id=org.kde.kdeconnect_tp"&gt;Play Store&lt;/a&gt; / &lt;a href="https://f-droid.org/packages/org.kde.kdeconnect_tp/"&gt;F-Droid&lt;/a&gt;), &lt;a href="https://openrepos.net/content/piggz/kde-connect"&gt;Sailfish OS&lt;/a&gt;</property>
                             <property name="use_markup">True</property>
                             <property name="track_visited_links">False</property>
                           </object>

--- a/data/settings.ui
+++ b/data/settings.ui
@@ -5,7 +5,7 @@
   <template class="GSConnectSettingsWindow" parent="GtkApplicationWindow">
     <property name="can_focus">False</property>
     <property name="default_width">640</property>
-    <property name="default_height">440</property>
+    <property name="default_height">580</property>
     <child type="titlebar">
       <object class="GtkHeaderBar" id="headerbar">
         <property name="visible">True</property>
@@ -845,7 +845,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
-                            <property name="top_attach">2</property>
+                            <property name="top_attach">3</property>
                           </packing>
                         </child>
                         <child>
@@ -873,66 +873,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
-                            <property name="top_attach">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkGrid">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="column_spacing">12</property>
-                            <child>
-                              <object class="GtkLinkButton">
-                                <property name="label" translatable="yes">Android</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="halign">start</property>
-                                <property name="relief">none</property>
-                                <property name="uri">https://play.google.com/store/apps/details?id=org.kde.kdeconnect_tp</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="top_attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLinkButton">
-                                <property name="label" translatable="yes">Sailfish OS</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="halign">start</property>
-                                <property name="relief">none</property>
-                                <property name="uri">https://openrepos.net/content/piggz/kde-connect</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">2</property>
-                                <property name="top_attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="height_request">32</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="valign">center</property>
-                                <property name="label" translatable="yes">KDE Connect</property>
-                                <attributes>
-                                  <attribute name="weight" value="bold"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="left_attach">0</property>
-                                <property name="top_attach">0</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
                             <property name="top_attach">3</property>
-                            <property name="width">2</property>
                           </packing>
                         </child>
                         <child>
@@ -949,6 +890,60 @@
                           <packing>
                             <property name="left_attach">1</property>
                             <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="valign">center</property>
+                            <property name="margin_bottom">8</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Browser Add-Ons</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="valign">center</property>
+                            <property name="margin_bottom">8</property>
+                            <property name="label" translatable="yes">KDE Connect</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">4</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="valign">baseline</property>
+                            <property name="margin_bottom">8</property>
+                            <property name="label" translatable="yes">Android (&lt;a href="https://play.google.com/store/apps/details?id=org.kde.kdeconnect_tp"&gt;Play Store&lt;/a&gt; / &lt;a href="https://f-droid.org/packages/org.kde.kdeconnect_tp/"&gt;F-Droid&lt;/a&gt;), &lt;a href="https://openrepos.net/content/piggz/kde-connect"&gt;Sailfish OS&lt;/a&gt;</property>
+                            <property name="use_markup">True</property>
+                            <property name="track_visited_links">False</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">5</property>
+                            <property name="width">2</property>
                           </packing>
                         </child>
                       </object>

--- a/src/service/plugins/findmyphone.js
+++ b/src/service/plugins/findmyphone.js
@@ -58,14 +58,6 @@ var Plugin = GObject.registerClass({
                 return;
             }
 
-            // Check for this every time to avoid possibly endless ringing
-            if (typeof loop_theme_sound !== 'function') {
-                let error = new Error();
-                error.name = 'DependencyError';
-                this.service.notify_error(error);
-                return;
-            }
-
             this._cancellable = new Gio.Cancellable();
             loop_theme_sound('phone-incoming-call', this._cancellable);
 

--- a/src/shell/gmenu.js
+++ b/src/shell/gmenu.js
@@ -131,8 +131,8 @@ var ListBox = class ListBox extends PopupMenu.PopupMenuSection {
         let menu = actor.get_parent()._delegate;
 
         if (menu.submenu && event.get_key_symbol() == Clutter.KEY_Left) {
+            menu.submenu.submenu_for.setActive(true);
             menu.submenu = null;
-            menu.firstMenuItem.setActive(true);
             return Clutter.EVENT_STOP;
         }
 
@@ -144,7 +144,7 @@ var ListBox = class ListBox extends PopupMenu.PopupMenuSection {
 
         if (item.submenu && event.get_key_symbol() == Clutter.KEY_Right) {
             this.submenu = item.submenu;
-            item.setActive(false);
+            item.submenu.firstMenuItem.setActive(true);
         }
 
         return Clutter.EVENT_PROPAGATE;


### PR DESCRIPTION
Currently this is only used in one case; incoming "Find My Phone"
requests, but it's always checked at startup and only once. This caches
the found (or not) backend to be used, while checking if/and when the
action is actually invoked.

This still isn't ideal, because it means we might not find out we can't
use an audible alert until the request happens, but still better and it
should be rare that at least canberra-gtk-play is not availale in GNOME.

fixes #276