### PR TITLE
Use ngettext for countable strings

### DIFF
--- a/po/org.gnome.Shell.Extensions.GSConnect.pot
+++ b/po/org.gnome.Shell.Extensions.GSConnect.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-03 21:57-0700\n"
+"POT-Creation-Date: 2018-11-04 12:18-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -286,7 +286,7 @@ msgid "Refresh"
 msgstr ""
 
 #. Service Menu
-#: src/extension.js:79 src/extension.js:248
+#: src/extension.js:79 src/extension.js:249
 msgid "Mobile Devices"
 msgstr ""
 
@@ -295,15 +295,18 @@ msgid "Mobile Settings"
 msgstr ""
 
 #. TRANSLATORS: Extension name
-#: src/extension.js:186 src/extension.js:300 src/service/daemon.js:95
+#: src/extension.js:186 src/extension.js:301 src/service/daemon.js:95
 #: src/service/daemon.js:413 webextension/gettext.js:27
 msgid "GSConnect"
 msgstr ""
 
-#: src/extension.js:246
+#. TRANSLATORS: %d is the number of devices connected
+#: src/extension.js:247
 #, javascript-format
 msgid "%d Connected"
-msgstr ""
+msgid_plural "%d Connected"
+msgstr[0] ""
+msgstr[1] ""
 
 #. TRANSLATORS: Top-level context menu item for GSConnect
 #: src/nautilus-gsconnect.py:112 webextension/gettext.js:31
@@ -828,8 +831,10 @@ msgstr ""
 #: src/service/ui/messaging.js:88 src/service/ui/messaging.js:120
 #: src/shell/donotdisturb.js:266
 #, javascript-format
-msgid "%d minutes"
-msgstr ""
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] ""
+msgstr[1] ""
 
 #. TRANSLATORS: Yesterday, but less than 24 hours (eg. Yesterday · 11:29 PM)
 #: src/service/ui/messaging.js:93

--- a/src/extension.js
+++ b/src/extension.js
@@ -243,7 +243,8 @@ class ServiceIndicator extends PanelMenu.SystemIndicator {
             }
         } else {
             if (this.available.length > 1) {
-                this._item.label.text = _('%d Connected').format(this.available.length);
+                //TRANSLATORS: %d is the number of devices connected
+                this._item.label.text = gsconnect.ngettext('%d Connected', '%d Connected', this.available.length).format(this.available.length);
             } else {
                 this._item.label.text = _('Mobile Devices');
             }
@@ -503,4 +504,3 @@ function disable() {
     serviceIndicator = null;
     Notification.unpatchGtkNotificationSources();
 }
-

--- a/src/service/ui/messaging.js
+++ b/src/service/ui/messaging.js
@@ -85,7 +85,7 @@ function getTime(time) {
         // Under an hour
         case (diff < GLib.TIME_SPAN_HOUR):
             // TRANSLATORS: Time duration in minutes (eg. 15 minutes)
-            return gsconnect.ngettext('%d minute', '%d minutes', (diff / GLib.TIME_SPAN_MINUTE)).format(diff / GLib.TIME_SPAN_MINUTE);
+            return ngettext('%d minute', '%d minutes', (diff / GLib.TIME_SPAN_MINUTE)).format(diff / GLib.TIME_SPAN_MINUTE);
 
         // Yesterday, but less than 24 hours ago
         case (diff < GLib.TIME_SPAN_DAY && (now.get_day_of_month() !== time.get_day_of_month())):
@@ -117,7 +117,7 @@ function getShortTime(time) {
 
         case (diff < GLib.TIME_SPAN_HOUR):
             // TRANSLATORS: Time duration in minutes (eg. 15 minutes)
-            return gsconnect.ngettext('%d minute', '%d minutes', (diff / GLib.TIME_SPAN_MINUTE)).format(diff / GLib.TIME_SPAN_MINUTE);
+            return ngettext('%d minute', '%d minutes', (diff / GLib.TIME_SPAN_MINUTE)).format(diff / GLib.TIME_SPAN_MINUTE);
 
         case (diff < (GLib.TIME_SPAN_DAY * 7)):
             return time.format('%a');

--- a/src/service/ui/messaging.js
+++ b/src/service/ui/messaging.js
@@ -85,7 +85,7 @@ function getTime(time) {
         // Under an hour
         case (diff < GLib.TIME_SPAN_HOUR):
             // TRANSLATORS: Time duration in minutes (eg. 15 minutes)
-            return _('%d minutes').format(diff / GLib.TIME_SPAN_MINUTE);
+            return gsconnect.ngettext('%d minute', '%d minutes', (diff / GLib.TIME_SPAN_MINUTE)).format(diff / GLib.TIME_SPAN_MINUTE);
 
         // Yesterday, but less than 24 hours ago
         case (diff < GLib.TIME_SPAN_DAY && (now.get_day_of_month() !== time.get_day_of_month())):
@@ -117,7 +117,7 @@ function getShortTime(time) {
 
         case (diff < GLib.TIME_SPAN_HOUR):
             // TRANSLATORS: Time duration in minutes (eg. 15 minutes)
-            return _('%d minutes').format(diff / GLib.TIME_SPAN_MINUTE);
+            return gsconnect.ngettext('%d minute', '%d minutes', (diff / GLib.TIME_SPAN_MINUTE)).format(diff / GLib.TIME_SPAN_MINUTE);
 
         case (diff < (GLib.TIME_SPAN_DAY * 7)):
             return time.format('%a');
@@ -936,4 +936,3 @@ var ConversationChooser = GObject.registerClass({
         }
     }
 });
-

--- a/src/shell/donotdisturb.js
+++ b/src/shell/donotdisturb.js
@@ -263,7 +263,7 @@ var Dialog = class Dialog extends ModalDialog.ModalDialog {
             return gsconnect.ngettext('One hour', '%d hours', hours).format(hours);
         } else {
             // TRANSLATORS: Time duration in minutes (eg. 15 minutes)
-            return gsconnect.ngettext('%d minute', '%d minutes', (this.time / 60)).format(this._time / 60);
+            return gsconnect.ngettext('%d minute', '%d minutes', (this._time / 60)).format(this._time / 60);
         }
     }
 

--- a/src/shell/donotdisturb.js
+++ b/src/shell/donotdisturb.js
@@ -263,7 +263,7 @@ var Dialog = class Dialog extends ModalDialog.ModalDialog {
             return gsconnect.ngettext('One hour', '%d hours', hours).format(hours);
         } else {
             // TRANSLATORS: Time duration in minutes (eg. 15 minutes)
-            return _('%d minutes').format(this._time / 60);
+            return gsconnect.ngettext('%d minute', '%d minutes', (this.time / 60)).format(this._time / 60);
         }
     }
 
@@ -307,4 +307,3 @@ var MenuItem = class MenuItem extends PopupMenu.PopupSwitchMenuItem {
         });
     }
 };
-


### PR DESCRIPTION
@piotrdrag pointed out that some countable strings weren't being translated using `ngettext`. This fixes that, and adds a translator comment on one of the strings. The `.pot` file is updated accordingly.

Fixes: #298