### PR TITLE
Fix type error in about dialog creation

### DIFF
--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -413,7 +413,7 @@ const Service = GObject.registerClass({
                 program_name: _('GSConnect'),
                 // TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
                 translator_credits: _('translator-credits'),
-                version: gsconnect.metadata.version,
+                version: gsconnect.metadata.version.toString(),
                 website: gsconnect.metadata.url,
                 license_type: Gtk.License.GPL_2_0
             });


### PR DESCRIPTION
Hi,

I noticed that the about dialog was not working and threw this error:
```
JS ERROR: Error: Wrong type integer; string expected
_init/Gtk.Widget.prototype._init@resource:///org/gnome/gjs/modules/overrides/Gtk.js:48:9
_aboutAction@/home/user/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/daemon.js:399:27
@/home/user/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/daemon.js:881:2
```
It turns out it was a type error with the `version` field of the AboutDialog object. It should be a string (see [here](https://devdocs.baznga.org/gtk20~2.24.31/gtk.aboutdialog#property-version)) but `gsconnect.metadata.version` is an integer.

Thanks for all the work and have a nice day =)