### PR TITLE
Add fallback launching for debug logs

### DIFF
--- a/data/debug.ui
+++ b/data/debug.ui
@@ -179,7 +179,7 @@
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Debug Terminal</property>
                     <property name="valign">center</property>
-                    <property name="action_name">app.log</property>
+                    <property name="action_name">win.log</property>
                     <child>
                       <object class="GtkImage">
                         <property name="visible">True</property>
@@ -876,3 +876,4 @@
     </child>
   </template>
 </interface>
+

--- a/src/service/components/debug.js
+++ b/src/service/components/debug.js
@@ -48,6 +48,10 @@ var Window = GObject.registerClass({
             visible: true
         });
 
+        // Log & Debug Mode actions
+        let logAction = new Gio.SimpleAction({name: 'log'});
+        logAction.connect('activate', this._logAction);
+        this.add_action(logAction);
         this.add_action(gsconnect.settings.create_action('debug'));
 
         // Watch for device changes
@@ -342,7 +346,7 @@ var Window = GObject.registerClass({
         this.application.disconnect(this._devicesChangedId);
     }
 
-    debugLog() {
+    _logAction() {
         try {
             GLib.spawn_command_line_async(
                 'gnome-terminal ' +
@@ -356,10 +360,18 @@ var Window = GObject.registerClass({
             let disp = new Gdk.Display;
             let ctx = disp.get_app_launch_context();
 
-            let app = Gio.AppInfo.create_from_commandline('journalctl -f -o cat /usr/bin/gjs', 'GJS', Gio.AppInfoCreateFlags.NEEDS_TERMINAL);
+            let app = Gio.AppInfo.create_from_commandline(
+                'journalctl -f -o cat /usr/bin/gjs',
+                'GJS',
+                Gio.AppInfoCreateFlags.NEEDS_TERMINAL
+            );
             app.launch([], ctx);
 
-            app = Gio.AppInfo.create_from_commandline('journalctl -f -o cat /usr/bin/gnome-shell', 'GNOME Shell', Gio.AppInfoCreateFlags.NEEDS_TERMINAL);
+            app = Gio.AppInfo.create_from_commandline(
+                'journalctl -f -o cat /usr/bin/gnome-shell',
+                'GNOME Shell',
+                Gio.AppInfoCreateFlags.NEEDS_TERMINAL
+            );
             app.launch([], ctx);
         }
     }

--- a/src/service/components/debug.js
+++ b/src/service/components/debug.js
@@ -4,6 +4,7 @@ const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
+const Gdk = imports.gi.Gdk;
 const System = imports.system;
 
 
@@ -342,12 +343,25 @@ var Window = GObject.registerClass({
     }
 
     debugLog() {
-        GLib.spawn_command_line_async(
-            'gnome-terminal ' +
-            //`--tab --title "GJS" --command "journalctl _PID=${getPID()} -f -o cat" ` +
-            '--tab --title "GJS" --command "journalctl -f -o cat /usr/bin/gjs" ' +
-            '--tab --title "GNOME Shell" --command "journalctl -f -o cat /usr/bin/gnome-shell"'
-        );
+        try {
+            GLib.spawn_command_line_async(
+                'gnome-terminal ' +
+                //`--tab --title "GJS" --command "journalctl _PID=${getPID()} -f -o cat" ` +
+                '--tab --title "GJS" --command "journalctl -f -o cat /usr/bin/gjs" ' +
+                '--tab --title "GNOME Shell" --command "journalctl -f -o cat /usr/bin/gnome-shell"'
+            );
+        } catch (e) {
+            // We couldn't launch gnome-terminal, fall back to Gio
+            logError(e);
+            let disp = new Gdk.Display;
+            let ctx = disp.get_app_launch_context();
+
+            let app = Gio.AppInfo.create_from_commandline('journalctl -f -o cat /usr/bin/gjs', 'GJS', Gio.AppInfoCreateFlags.NEEDS_TERMINAL);
+            app.launch([], ctx);
+
+            app = Gio.AppInfo.create_from_commandline('journalctl -f -o cat /usr/bin/gnome-shell', 'GNOME Shell', Gio.AppInfoCreateFlags.NEEDS_TERMINAL);
+            app.launch([], ctx);
+        }
     }
 
     /**
@@ -381,4 +395,3 @@ var Window = GObject.registerClass({
         System.gc();
     }
 });
-

--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -319,7 +319,6 @@ const Service = GObject.registerClass({
             // Misc service actions
             ['broadcast', this.broadcast.bind(this)],
             ['error', this._errorAction.bind(this), 'a{ss}'],
-            ['log', this._logAction.bind(this)],
             ['debugger', this._debuggerAction.bind(this)],
             ['wiki', this._wikiAction.bind(this), 's'],
             ['quit', () => this.quit()]
@@ -457,31 +456,6 @@ const Service = GObject.registerClass({
             dialog.show();
         } catch (e) {
             logError(e);
-        }
-    }
-
-    _logAction() {
-        // Ensure debugging is enabled
-        gsconnect.settings.set_boolean('debug', true);
-
-        try {
-            // Launch a terminal with tabs for GJS and GNOME Shell
-            GLib.spawn_command_line_async(
-                'gnome-terminal ' +
-                '--tab --title "GJS" --command "journalctl -f -o cat /usr/bin/gjs" ' +
-                '--tab --title "GNOME Shell" --command "journalctl -f -o cat /usr/bin/gnome-shell"'
-            );
-        } catch (e) {
-            // We couldn't launch gnome-terminal, fall back to Gio
-            logError(e);
-            let disp = new Gdk.Display;
-            let ctx = disp.get_app_launch_context();
-
-            let app = Gio.AppInfo.create_from_commandline('journalctl -f -o cat /usr/bin/gjs', 'GJS', Gio.AppInfoCreateFlags.NEEDS_TERMINAL);
-            app.launch([], ctx);
-
-            app = Gio.AppInfo.create_from_commandline('journalctl -f -o cat /usr/bin/gnome-shell', 'GNOME Shell', Gio.AppInfoCreateFlags.NEEDS_TERMINAL);
-            app.launch([], ctx);
         }
     }
 
@@ -873,3 +847,4 @@ const Service = GObject.registerClass({
 });
 
 (new Service()).run([System.programInvocationName].concat(ARGV));
+


### PR DESCRIPTION
If launching `gnome-terminal` directly fails, we fall back to launching the two `journalctl` commands via Gio.AppInfo's "NEEDS_TERMINAL" application launcher. Should automatically bring up whatever recognized terminal emulator is installed.

In my testing, after installing `rxvt` and uninstalling `gnome-terminal` completely, hitting the terminal-launcher in the extension's Debug window got me two terminal windows, each showing one of the two GSConnect debug log views.

(To be honest, I wasn't sure what `debug.js` was for, but I noticed that terminal launching was also present there, so I added the same fallback logic to that code as in `daemon.js`. It'll never be used unless `gnome-terminal` isn't installed, so I figure it was safe enough to add anyway.)

Fixes #329