### PR TITLE
French translations (issue with hour ?)

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-11-19 11:14-0800\n"
-"PO-Revision-Date: 2018-12-08 11:23+0100\n"
+"PO-Revision-Date: 2018-12-08 11:32+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -164,7 +164,6 @@ msgstr "À propos"
 
 #. TRANSLATORS: Change the connection type to Bluetooth
 #: data/menus.ui:34
-#, fuzzy
 msgid "Switch to Bluetooth"
 msgstr "Se connecter en Bluetooth"
 
@@ -220,9 +219,8 @@ msgid "Messaging"
 msgstr "Messagerie"
 
 #: data/messaging.ui:110
-#, fuzzy
 msgid "Select a conversation"
-msgstr "Ajouter des personnes pour démarrer une conversation"
+msgstr "Sélectionner une conversation"
 
 #: data/messaging.ui:188
 msgid "Device is disconnected"
@@ -727,7 +725,7 @@ msgstr "Appel sortant"
 
 #. TRANSLATORS: All other phone number types
 #: src/service/ui/contacts.js:58 src/service/ui/contacts.js:79
-#, fuzzy, javascript-format
+#, javascript-format
 msgid "%s・Other"
 msgstr "%s・Autre"
 
@@ -739,19 +737,19 @@ msgstr "%s・Fax"
 
 #. TRANSLATORS: A work phone number
 #: src/service/ui/contacts.js:67
-#, fuzzy, javascript-format
+#, javascript-format
 msgid "%s・Work"
 msgstr "%s・Travail"
 
 #. TRANSLATORS: A mobile or cellular phone number
 #: src/service/ui/contacts.js:71
-#, fuzzy, javascript-format
+#, javascript-format
 msgid "%s・Mobile"
 msgstr "%s・Mobile"
 
 #. TRANSLATORS: A home phone number
 #: src/service/ui/contacts.js:75
-#, fuzzy, javascript-format
+#, javascript-format
 msgid "%s・Home"
 msgstr "%s・Maison"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-11-19 11:14-0800\n"
-"PO-Revision-Date: 2018-12-08 11:32+0100\n"
+"PO-Revision-Date: 2018-12-08 13:56+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -766,7 +766,7 @@ msgstr "Envoyer vers %s"
 #. TRANSLATORS: Title of keyboard shortcut dialog
 #: src/service/ui/keybindings.js:33
 msgid "Set Shortcut"
-msgstr "Définir un raccourcis"
+msgstr "Définir un raccourci"
 
 #. TRANSLATORS: Button to confirm the new shortcut
 #: src/service/ui/keybindings.js:47

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-11-19 11:14-0800\n"
-"PO-Revision-Date: 2018-11-05 19:14+0100\n"
+"PO-Revision-Date: 2018-12-08 11:23+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: Poedit 2.0.6\n"
+"X-Generator: Poedit 2.2\n"
 
 #: data/conversation.ui:71 data/conversation.ui:79
 msgid "Type a message"
@@ -44,7 +44,7 @@ msgstr "Souris et clavier"
 
 #: data/device.ui:268
 msgid "Volume Control"
-msgstr "Contrôle du volume"
+msgstr "Gestion du volume"
 
 #: data/device.ui:308 data/device.ui:1406
 msgid "Sharing"
@@ -171,7 +171,7 @@ msgstr "Se connecter en Bluetooth"
 #. TRANSLATORS: Change the connection type to TCP/IP
 #: data/menus.ui:41
 msgid "Switch to LAN"
-msgstr ""
+msgstr "Se connecter au réseau local"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
 #: data/menus.ui:48 src/service/ui/settings.js:612
@@ -462,9 +462,8 @@ msgid "Accept"
 msgstr "Accepter"
 
 #: src/service/plugins/battery.js:194 src/service/plugins/findmyphone.js:18
-#, fuzzy
 msgid "Ring"
-msgstr "Localisation"
+msgstr "Faire sonner"
 
 #. TRANSLATORS: eg. Google Pixel: Battery is low
 #: src/service/plugins/battery.js:203
@@ -758,7 +757,7 @@ msgstr "%s・Maison"
 
 #: src/service/ui/contacts.js:203
 msgid "Select a contact or number"
-msgstr ""
+msgstr "Sélectionner un contact ou un numéro"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
 #: src/service/ui/contacts.js:239 src/service/ui/contacts.js:253


### PR DESCRIPTION
My first contribution, 

My POEditor told me there is an issue with One hour / %d hours.
I checked for minutes and it's displayed differently : 
```
msgid "One hour"
msgid_plural "%d hours"
msgstr[0] "Une heure"
msgstr[1] "%d heures"
```
```
msgid "%d minute"
msgid_plural "%d minutes"
msgstr[0] "%d minute"
msgstr[1] "%d minutes"
```

To me, msgId for hour should be "%d hour" to be more consistent with minutes.

Hope this helps.