### PR TITLE
Notification Plugin: Improve repliable notifications

### DIFF
--- a/data/notification.ui
+++ b/data/notification.ui
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <template class="GSConnectNotificationReplyDialog" parent="GtkDialog">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Reply Notification</property>
+    <property name="default_width">320</property>
+    <property name="default_height">300</property>
+    <property name="type_hint">dialog</property>
+    <child type="action">
+      <object class="GtkButton" id="cancel-button">
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Cancel</property>
+        <property name="visible">True</property>
+     </object>
+    </child>
+    <child type="action">
+      <object class="GtkButton" id="send-button">
+        <property name="can-default">True</property>
+        <property name="label" translatable="yes">Send</property>
+        <property name="visible">True</property>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="cancel">cancel-button</action-widget>
+      <action-widget response="ok" default="true">send-button</action-widget>
+    </action-widgets>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="border_width">12</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkRevealer" id="infobar">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkInfoBar">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="message_type">warning</property>
+                <child internal-child="content_area">
+                  <object class="GtkBox">
+                    <property name="can_focus">False</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Device is disconnected</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+            <style>
+              <class name="info"/>
+            </style>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="row_spacing">12</property>
+            <child>
+              <object class="GtkScrolledWindow">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="hscrollbar_policy">never</property>
+                <property name="shadow_type">in</property>
+                <child>
+                  <object class="GtkViewport">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkTextView" id="message-entry">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="border_width">6</property>
+                        <property name="wrap_mode">word-char</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">12</property>
+                <child>
+                  <object class="GtkLabel" id="notification-title">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label">Notification Title</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="shadow_type">in</property>
+                    <child>
+                      <object class="GtkViewport">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="border_width">6</property>
+                        <child>
+                          <object class="GtkLabel" id="notification-body">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label">Notification Body</property>
+                            <property name="use_markup">True</property>
+                            <property name="vexpand">True</property>
+                            <property name="wrap">True</property>
+                            <property name="wrap_mode">word-char</property>
+                            <property name="xalign">0</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>
+

--- a/data/org.gnome.Shell.Extensions.GSConnect.gresource.xml
+++ b/data/org.gnome.Shell.Extensions.GSConnect.gresource.xml
@@ -9,6 +9,7 @@
     <file compressed="true" preprocess="xml-stripblanks">devel.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">device.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">messaging.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">notification.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">settings.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">telephony.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">enter-keyboard-shortcut.svg</file>

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -33,4 +33,5 @@ src/service/ui/settings.js
 src/service/ui/telephony.js
 src/shell/device.js
 src/shell/donotdisturb.js
+src/shell/notification.js
 webextension/gettext.js

--- a/src/service/ui/notification.js
+++ b/src/service/ui/notification.js
@@ -1,0 +1,130 @@
+'use strict';
+
+const Gio = imports.gi.Gio;
+const GObject = imports.gi.GObject;
+const Gtk = imports.gi.Gtk;
+
+
+var Dialog = GObject.registerClass({
+    GTypeName: 'GSConnectNotificationReplyDialog',
+    Properties: {
+        'device': GObject.ParamSpec.object(
+            'device',
+            'Device',
+            'The device associated with this window',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.Object
+        )
+    },
+    Template: 'resource:///org/gnome/Shell/Extensions/GSConnect/notification.ui',
+    Children: [
+        'infobar',
+        'notification-title', 'notification-body',
+        'message-entry'
+    ]
+}, class Dialog extends Gtk.Dialog {
+
+    _init(params) {
+        this.connect_template();
+        super._init({
+            application: Gio.Application.get_default(),
+            device: params.device,
+            use_header_bar: true
+        });
+
+        this.uuid = params.uuid;
+
+        this.set_response_sensitive(Gtk.ResponseType.OK, false);
+
+        // Info bar
+        this.device.bind_property(
+            'connected',
+            this.infobar,
+            'reveal-child',
+            GObject.BindingFlags.INVERT_BOOLEAN
+        );
+
+        // Notification Data
+        let headerbar = this.get_titlebar();
+        headerbar.title = params.notification.appName;
+        headerbar.subtitle = this.device.name;
+
+        this.notification_title.label = params.notification.title;
+        this.notification_body.label = params.notification.text.linkify();
+
+        // Message Entry/Send Button
+        this.device.bind_property(
+            'connected',
+            this.message_entry,
+            'sensitive',
+            GObject.BindingFlags.DEFAULT
+        );
+
+        this._connectedId = this.device.connect(
+            'notify::connected',
+            this._onStateChanged.bind(this)
+        );
+
+        this._entryChangedId = this.message_entry.buffer.connect(
+            'changed',
+            this._onStateChanged.bind(this)
+        );
+
+        // Cleanup on ::destroy
+        this.connect('destroy', this._onDestroy);
+    }
+
+    vfunc_response(response_id) {
+        if (response_id === Gtk.ResponseType.OK) {
+            // Refuse to send empty or whitespace only messages
+            if (!this.message_entry.buffer.text.trim()) return;
+
+            this.plugin.replyNotification(
+                this.uuid,
+                this.message_entry.buffer.text
+            );
+        }
+
+        this.destroy();
+    }
+
+    get uuid() {
+        return this._uuid;
+    }
+
+    set uuid(uuid) {
+        // We must have a UUID
+        if (uuid) {
+            this._uuid = uuid;
+        } else {
+            this.destroy();
+            warning('no uuid for repliable notification');
+        }
+    }
+
+    get plugin() {
+        if (!this._plugin) {
+            this._plugin = this.device.lookup_plugin('notification');
+        }
+
+        return this._plugin;
+    }
+
+    _onDestroy(window) {
+        window.device.disconnect(window._connectedId);
+        window.message_entry.buffer.disconnect(window._entryChangedId);
+        window.disconnect_template();
+    }
+
+    _onStateChanged() {
+        switch (false) {
+            case this.device.connected:
+            case (this.message_entry.buffer.text.trim() !== ''):
+                break;
+
+            default:
+                this.set_response_sensitive(Gtk.ResponseType.OK, true);
+        }
+    }
+});
+


### PR DESCRIPTION
* Add a dialog as the default action for repliable notifications

  If the quick reply features is not used, the notification can be
  replied to by clicking on the body of the notification at any time.

  fixes #381

* Add an intermediate button to quick reply notifications

  In order to avoid accidentally sending replies to notifications, there
  is now an intermediate button that must be clicked before the entry is
  shown and takes keyboard focus.

  fixes #376