### PR TITLE
Add Experimental switch to force GVFS use

### DIFF
--- a/data/device.ui
+++ b/data/device.ui
@@ -1555,6 +1555,59 @@
                                 </accessibility>
                               </object>
                             </child>
+                            <child>
+                              <object class="GtkListBoxRow" id="use-gvfs-row">
+                                <property name="height_request">56</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="action_name">settings.use-gvfs</property>
+                                <property name="selectable">False</property>
+                                <child>
+                                  <object class="GtkGrid">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_left">12</property>
+                                    <property name="margin_right">12</property>
+                                    <property name="column_spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="use-gvfs-label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="vexpand">True</property>
+                                        <property name="label" translatable="yes">Use GVFS for file access</property>
+                                        <accessibility>
+                                          <relation type="label-for" target="use-gvfs-row"/>
+                                          <relation type="label-for" target="use-gvfs"/>
+                                        </accessibility>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSwitch" id="use-gvfs">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="halign">end</property>
+                                        <property name="valign">center</property>
+                                        <property name="action_name">settings.use-gvfs</property>
+                                        <accessibility>
+                                          <relation type="labelled-by" target="use-gvfs-label"/>
+                                        </accessibility>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">0</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
                             <accessibility>
                               <relation type="labelled-by" target="experimental-label"/>
                             </accessibility>

--- a/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
+++ b/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
@@ -142,7 +142,11 @@
       <default>{}</default>
     </key>
   </schema>
-  <schema id="org.gnome.Shell.Extensions.GSConnect.Plugin.SFTP"/>
+  <schema id="org.gnome.Shell.Extensions.GSConnect.Plugin.SFTP">
+    <key name="use-gvfs" type="b">
+      <default>false</default>
+    </key>
+  </schema>
   <schema id="org.gnome.Shell.Extensions.GSConnect.Plugin.Share"/>
   <schema id="org.gnome.Shell.Extensions.GSConnect.Plugin.SMS">
     <key name="legacy-sms" type="b">

--- a/src/service/plugins/sftp.js
+++ b/src/service/plugins/sftp.js
@@ -52,6 +52,10 @@ var Plugin = GObject.registerClass({
     }
 
     get has_sshfs() {
+        // Short-circuit to false if GVFS override is enabled
+        if (this.settings.get_boolean('use-gvfs')) {
+            return false;
+        }
         return GLib.find_program_in_path(gsconnect.metadata.bin.sshfs);
     }
 

--- a/src/service/ui/device.js
+++ b/src/service/ui/device.js
@@ -387,6 +387,9 @@ var DevicePreferences = GObject.registerClass({
         settings = this._getSettings('sms');
         this.actions.add_action(settings.create_action('legacy-sms'));
 
+        settings = this._getSettings('sftp');
+        this.actions.add_action(settings.create_action('use-gvfs'));
+
         settings = this._getSettings('systemvolume');
         this.actions.add_action(settings.create_action('share-sinks'));
 


### PR DESCRIPTION
Thought I'd formalize my previous hack, since the Experimental section was added to device settings. Reversed the user-facing logic to "use (force) GVFS" instead of "disable sshfs", even though conceptually it's really still doing the latter.