### PR TITLE
Allow sshfs to connect with old crypto protocols

### DIFF
--- a/src/service/plugins/sftp.js
+++ b/src/service/plugins/sftp.js
@@ -322,6 +322,10 @@ var Plugin = GObject.registerClass({
                 '-f',
                 // Do not use ~/.ssh/config
                 '-F', '/dev/null',
+                // Allow older crypographic protocols
+                '-o', 'HostKeyAlgorithms=+ssh-dss',
+                '-o', 'MACs=+hmac-sha1',
+                '-o', 'KexAlgorithms=+diffie-hellman-group1-sha1',
                 // Use the private key from the service certificate
                 '-o', 'IdentityFile=' + gsconnect.configdir + '/private.pem',
                 // Don't prompt for new host confirmation (we know the host)


### PR DESCRIPTION
A mismatch between a new ssh installation on the desktop and
an older ssh on Android may lead to a broken sshfs connection.

Maybe you can consider even other protocols to allow, but this already works for my case where the annonced options of the Android device were:

```
HostKeyAlgorithms ssh-dss
KexAlgorithms diffie-hellman-group14-sha1,diffie-hellman-group1-sha1
MACs hmac-md5,hmac-sha1,hmac-md5-96,hmac-sha1-96
```
