### PR TITLE
Follow the GNOME primary menu design guidelines

### DIFF
--- a/data/menus.ui
+++ b/data/menus.ui
@@ -35,7 +35,7 @@
         <attribute name="target">Help</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">About</attribute>
+        <attribute name="label" translatable="yes">About GSConnect</attribute>
         <attribute name="action">win.about</attribute>
       </item>
     </section>


### PR DESCRIPTION
Use About GSConnect instead of About on the primary menu

https://gitlab.gnome.org/GNOME/Initiatives/issues/4