### PR TITLE
Fix missing closing html tag in German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -790,7 +790,7 @@ msgstr "Setze"
 #: src/service/ui/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
-msgstr "Gebe ein neues Tastenkürzel ein um <b>%s<b> zu Ändern"
+msgstr "Gebe ein neues Tastenkürzel ein um <b>%s</b> zu Ändern"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
 #: src/service/ui/keybindings.js:83


### PR DESCRIPTION
The keybinding editor fails to start in the current version, producing this error:

> Feb 24 15:10:55 hagrid gjs[13376]: Failed to set text 'Gebe ein neues Tastenkürzel ein um \<b>Einstellungen\<b> zu Ändern' from markup due to error parsing markup: Fehler in Zeile 1, Zeichen 83: Element »markup« wurde geschlossen, aber das derzeit offene Element ist »b«

There was simply a missing `/` in the translation file causing the HTML parser to fail. This PR inserts the missing `/`.