### PR TITLE
Clipboard: add XWayland subprocess for clipboard on Wayland

### DIFF
--- a/src/service/components/clipboard.js
+++ b/src/service/components/clipboard.js
@@ -1,0 +1,139 @@
+'use strict';
+
+const Gdk = imports.gi.Gdk;
+const Gtk = imports.gi.Gtk;
+const Gio = imports.gi.Gio;
+const GObject = imports.gi.GObject;
+
+
+var Clipboard = GObject.registerClass({
+    GTypeName: 'GSConnectClipboard',
+    Signals: {
+        'owner-change': {
+            flags: GObject.SignalFlags.RUN_FIRST,
+            param_types: [GObject.TYPE_STRING]
+        }
+    }
+}, class Clipboard extends GObject.Object {
+
+    _init() {
+        super._init();
+        
+        this._buffer = null;
+        this._proc = null;
+        
+        try {
+            // On Wayland we use a small subprocess running in XWayland where
+            // GtkClipboard still functions properly.
+            if (_WAYLAND) {
+                this._proc = new Gio.Subprocess({
+                    argv: [gsconnect.extdatadir + '/service/components/xclipboard'],
+                    flags: Gio.SubprocessFlags.STDIN_PIPE |
+                           Gio.SubprocessFlags.STDOUT_PIPE |
+                           Gio.SubprocessFlags.STDERR_SILENCE
+                });
+                this._proc.init(null);
+                
+                // IO Channels
+                this._stdin = new Gio.DataInputStream({
+                    base_stream: this._proc.get_stdout_pipe(),
+                    byte_order: Gio.DataStreamByteOrder.HOST_ENDIAN
+                });
+
+                this._stdout = new Gio.DataOutputStream({
+                    base_stream: this._proc.get_stdin_pipe(),
+                    byte_order: Gio.DataStreamByteOrder.HOST_ENDIAN
+                });
+
+                let source = this._stdin.base_stream.create_source(null);
+                source.set_callback(this._readContent.bind(this));
+                source.attach(null);
+                
+            // If we're in X11/Xorg we're just a wrapper around GtkClipboard
+            } else {
+                let display = Gdk.Display.get_default();
+                this._clipboard = Gtk.Clipboard.get_default(display);
+                
+                this._ownerChangeId = this._clipboard.connect(
+                    'owner-change',
+                    this._proxyOwnerChange.bind(this)
+                );
+            }
+        } catch (e) {
+            logError(e, 'Clipboard');
+        }
+    }
+    
+    _proxyOwnerChange(clipboard, event) {
+        this.emit('owner-change', '');
+    }
+    
+    _readContent() {
+        try {
+            // Read the message
+            let length = this._stdin.read_int32(null);
+            let text = this._stdin.read_bytes(length, null).toArray();
+
+            if (text instanceof Uint8Array) {
+                text = imports.byteArray.toString(text);
+            }
+            
+            this._buffer = text;
+            this._proxyOwnerChange();
+
+            return true;
+        } catch (e) {
+            logError(e);
+        }
+    }
+    
+    _writeContent(text) {
+        try {
+            this._stdout.put_int32(text.length, null);
+            this._stdout.put_string(text, null);
+        } catch (e) {
+            logError(e, 'Clipboard');
+        }
+    }
+    
+    set_text(text, length) {
+        try {
+            if (_WAYLAND) {
+                this._writeContent(text);
+            } else {
+                this._clipboard.set_text(text, length);
+            }
+        } catch (e) {
+            logError(e, 'Clipboard');
+        }
+    }
+    
+    request_text(callback) {
+        try {
+            if (_WAYLAND) {
+                callback(this, this._buffer);
+            } else {
+                this._clipboard.request_text(callback);
+            }
+        } catch (e) {
+            logError(e, 'Clipboard');
+        }
+    }
+    
+    destroy() {
+        if (this._proc) {
+            this._proc.force_exit(null);
+        }
+        
+        if (this._ownerChangeId) {
+            this._clipboard.disconnect(this._ownerChangeId);
+        }
+    }
+});
+
+
+/**
+ * The service class for this component
+ */
+var Service = Clipboard;
+

--- a/src/service/components/xclipboard
+++ b/src/service/components/xclipboard
@@ -1,0 +1,83 @@
+#!/usr/bin/env gjs
+
+'use strict';
+
+const Gdk = imports.gi.Gdk;
+const Gio = imports.gi.Gio;
+const Gtk = imports.gi.Gtk;
+
+Gdk.set_allowed_backends('x11,*');
+
+Gtk.init (null);
+
+const clipboard = Gtk.Clipboard.get_default(Gdk.Display.get_default());
+var buffer = null;
+
+/*
+ * We use stdin and stdout to pipe changes to the parent process
+ */
+const stdin = new Gio.DataInputStream({
+    base_stream: new Gio.UnixInputStream({fd: 0}),
+    byte_order: Gio.DataStreamByteOrder.HOST_ENDIAN
+});
+
+const stdout = new Gio.DataOutputStream({
+    base_stream: new Gio.UnixOutputStream({fd: 1}),
+    byte_order: Gio.DataStreamByteOrder.HOST_ENDIAN
+});
+
+/*
+ * Read and write changes
+ */
+function readContent(text) {
+    try {
+        // Read the message
+        let length = stdin.read_int32(null);
+        let text = stdin.read_bytes(length, null).toArray();
+
+        if (text instanceof Uint8Array) {
+            text = imports.byteArray.toString(text);
+        }
+        
+        buffer = text;
+        clipboard.set_text(text, -1);
+    } catch (e) {
+        logError(e);
+    }
+    
+    return true;
+}
+
+function writeContent(text) {
+    try {
+        stdout.put_int32(text.length, null);
+        stdout.put_string(text, null);
+    } catch (e) {
+        logError(e);
+    }
+}
+
+/*
+ * When the clipboard changes, we send it to stdout (eg. the parent process)
+ */
+function onOwnerChange(clipboard, text) {
+    clipboard.request_text((clipboard, text) => {
+        // Prevent repeating duplicate copies
+        if (buffer != text) {
+            buffer = text;
+            writeContent(text);
+        }
+    });
+}
+
+clipboard.connect('owner-change', onOwnerChange);
+
+/*
+ * Watch stdin for incoming content
+ */
+let source = stdin.base_stream.create_source(null);
+source.set_callback(readContent);
+source.attach(null);
+
+Gtk.main();
+

--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -133,8 +133,8 @@ const Service = GObject.registerClass({
             });
 
             for (let name in imports.service.plugins) {
-                // Don't report clipbaord/mousepad support in Wayland sessions
-                if (_WAYLAND && ['clipboard', 'mousepad'].includes(name)) continue;
+                // Don't report mousepad support in Wayland sessions
+                if (_WAYLAND && name == 'mousepad') continue;
 
                 let meta = imports.service.plugins[name].Metadata;
 
@@ -278,7 +278,10 @@ const Service = GObject.registerClass({
         if (device) {
             // Stash the settings path before unpairing and removing
             let settings_path = device.settings.path;
-            device.sendPacket({type: 'kdeconnect.pair', pair: 'false'});
+            device.sendPacket({
+                type: 'kdeconnect.pair',
+                body: {pair: false}
+            });
 
             //
             device.destroy();
@@ -724,6 +727,12 @@ const Service = GObject.registerClass({
         this._devices.forEach(device => device.destroy());
 
         // Destroy the remaining components last
+        try {
+            if (this.clipboard) this.clipboard.destroy();
+        } catch (e) {
+            debug(e);
+        }
+        
         try {
             if (this.mpris) this.mpris.destroy();
         } catch (e) {

--- a/src/service/device.js
+++ b/src/service/device.js
@@ -219,11 +219,9 @@ var Device = GObject.registerClass({
     get supported_plugins() {
         let supported = this.settings.get_strv('supported-plugins');
 
-        // Preempt clipboard and mousepad plugins on Wayland
+        // Preempt mousepad plugin on Wayland
         if (_WAYLAND) {
-            supported = supported.filter(name => {
-                return (name !== 'clipboard' && name !== 'mousepad');
-            });
+            supported = supported.filter(name => (name !== 'mousepad'));
         }
 
         return supported;

--- a/src/service/plugins/clipboard.js
+++ b/src/service/plugins/clipboard.js
@@ -45,8 +45,7 @@ var Plugin = GObject.registerClass({
         super._init(device, 'clipboard');
 
         try {
-            let display = Gdk.Display.get_default();
-            this._clipboard = Gtk.Clipboard.get_default(display);
+            this._clipboard = this.service.clipboard;
         } catch (e) {
             this.destroy();
             throw e;


### PR DESCRIPTION
Since GtkClipboard isn't working well under Wayland, we start a small
subprocess and force the GdkX11 backend. We then pipe clipboard changes
back and forth over stdin/stdout.

closes #454