### PR TITLE
Nemo compatibility for nautilus-gsconnect.py

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -109,6 +109,9 @@ if get_option('nautilus')
     'src/nautilus-gsconnect.py',
     install_dir: join_paths(datadir, 'nautilus-python', 'extensions')
   )
+endif
+
+if get_option('nemo')
   install_data(
     'src/nautilus-gsconnect.py',
     install_dir: join_paths(datadir, 'nemo-python', 'extensions')

--- a/meson.build
+++ b/meson.build
@@ -103,11 +103,15 @@ configure_file(
   install_dir: dbus_dir
 )
 
-# Nautilus Extension
+# Nautilus/Nemo Extension
 if get_option('nautilus')
   install_data(
     'src/nautilus-gsconnect.py',
     install_dir: join_paths(datadir, 'nautilus-python', 'extensions')
+  )
+  install_data(
+    'src/nautilus-gsconnect.py',
+    install_dir: join_paths(datadir, 'nemo-python', 'extensions')
   )
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -75,12 +75,12 @@ option(
   description: 'Path to sshfs binary'
 )
 
-# Enable/Disable Nautilus extension installation
+# Enable/Disable Nautilus/Nemo Python extension installation
 option(
   'nautilus',
   type: 'boolean',
   value: true,
-  description: 'Install nautilus-python extension'
+  description: 'Install file browser extension for Nautilus/Nemo'
 )
 
 # Enable/Disable WebExtension manifest installation
@@ -112,4 +112,3 @@ option(
   value: '',
   description: 'Native Messaging Host directory for Mozilla'
 )
-

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -75,12 +75,20 @@ option(
   description: 'Path to sshfs binary'
 )
 
-# Enable/Disable Nautilus/Nemo Python extension installation
+# Enable/Disable Nautilus Python extension installation
 option(
   'nautilus',
   type: 'boolean',
   value: true,
-  description: 'Install file browser extension for Nautilus/Nemo'
+  description: 'Install file browser extension for Nautilus'
+)
+
+# Enable/Disable Nemo Python extension installation
+option(
+  'nemo',
+  type: 'boolean',
+  value: true,
+  description: 'Install file browser extension for Nemo'
 )
 
 # Enable/Disable WebExtension manifest installation

--- a/src/nautilus-gsconnect.py
+++ b/src/nautilus-gsconnect.py
@@ -12,11 +12,26 @@ import locale
 import os.path
 
 import gi
-gi.require_version('Nautilus', '3.0')
 gi.require_version('Gio', '2.0')
 gi.require_version('GLib', '2.0')
 gi.require_version('GObject', '2.0')
-from gi.repository import Nautilus, Gio, GLib, GObject
+from gi.repository import Gio, GLib, GObject
+
+import sys
+
+# Host application detection
+#
+# Nemo seems to reliably identify itself as 'nemo' in argv[0], so we
+# can test for that. Nautilus detection is less reliable, so don't try.
+# See https://github.com/linuxmint/nemo-extensions/issues/330
+if "nemo" in sys.argv[0].lower():
+    # Host runtime is nemo-python
+    gi.require_version('Nemo', '3.0')
+    from gi.repository import Nemo as FileManager
+else:
+    # Otherwise, just assume it's nautilus-python
+    gi.require_version('Nautilus', '3.0')
+    from gi.repository import Nautilus as FileManager
 
 _ = gettext.gettext
 
@@ -34,7 +49,7 @@ SERVICE_PATH = '/org/gnome/Shell/Extensions/GSConnect'
 
 
 
-class GSConnectShareExtension(GObject.Object, Nautilus.MenuProvider):
+class GSConnectShareExtension(GObject.Object, FileManager.MenuProvider):
     """A context menu for sending files via GSConnect."""
 
     def __init__(self):
@@ -144,18 +159,18 @@ class GSConnectShareExtension(GObject.Object, Nautilus.MenuProvider):
             return ()
 
         # Context Menu Item
-        menu = Nautilus.MenuItem(
+        menu = FileManager.MenuItem(
             name='GSConnectShareExtension::Devices',
             label=_('Send To Mobile Device')
         )
 
         # Context Submenu
-        submenu = Nautilus.Menu()
+        submenu = FileManager.Menu()
         menu.set_submenu(submenu)
 
         # Context Submenu Items
         for name, action_group in devices:
-            item = Nautilus.MenuItem(
+            item = FileManager.MenuItem(
                 name='GSConnectShareExtension::Device' + name,
                 label=name
             )


### PR DESCRIPTION
This PR rewrites `nautilus-gsconnect.py` to be installable in `nemo-python` as well, detecting which application is hosting the plugin by checking for the string "nemo" in `sys.argv[0]`. (Nautilus is the assumed default if there's no match.)

~The process of conforming to a given browser is not quite automatic yet, and requires a setting `FILE_MANAGER="Nautilus"` or `FILE_MANAGER="Nemo"` at the start of the file. So far I haven't found a way for the code to make that determination automatically. If that gets sorted out, the exact same code will be installable for both apps, and we won't have to maintain two versions of the extension.~

Remaining TODOs before this is mergeable:
- [x] One of the following:
    - [x] Figure out nautilus-vs-nemo autodetection (done, though see #579 and linuxmint/nemo#330)
    - ~Create a `nemo-gsconnect.py` customized for Nemo, to go alongside `nautilus-gsconnect.py`~
- [x] Add `$HOME/.local/share/nemo-python/extensions/` install-symlinking to `_gsconnect.js`
- [x] Add Nemo extension installation to meson, for systemwide installs

Fixes #579 