### PR TITLE
gmenu: Fix out-of-range value crashes

### DIFF
--- a/src/service/protocol/__init__.js
+++ b/src/service/protocol/__init__.js
@@ -83,7 +83,7 @@ Object.defineProperties(Gio.TlsCertificate.prototype, {
                 proc.init(null);
 
                 let stdout = proc.communicate_utf8(this.certificate_pem, null)[1];
-                this.__common_name = /(?:cn|CN)\ ?=\ ?([^,]*)/.exec(stdout)[1];
+                this.__common_name = /(?:cn|CN) ?= ?([^,]*)/.exec(stdout)[1];
 
                 proc.wait_check(null);
             }

--- a/src/shell/gmenu.js
+++ b/src/shell/gmenu.js
@@ -136,7 +136,7 @@ var ListBox = class ListBox extends PopupMenu.PopupMenuSection {
         // We use this instead of close() to avoid touching finalized objects
         } else {
             this.box.opacity = 255;
-            this.box.width = -1;
+            this.box.width = 0;
             this.box.visible = true;
 
             this._submenu = null;


### PR DESCRIPTION
v25 release under 3.32.2 was failing to open the settings window, due to an out-of-range value in `gmenu.js`. 

Traceback:
```
Sep 10 07:02:01 gnome-shell[2322]: value "-1.000000" of type 'gfloat' is invalid or out of range for property 'width' of type 'gfloat'
Sep 10 07:02:01 org.gnome.Shell.desktop[2322]: == Stack trace for context 0x56297bfd2310 ==
Sep 10 07:02:01 org.gnome.Shell.desktop[2322]: #0   5629879349d8 i   /home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/shell/gmenu.js:139 (7fcb5cb920d0 @ 70)
Sep 10 07:02:01 org.gnome.Shell.desktop[2322]: #1   7ffc1dfba7a0 b   self-hosted:979 (7fcb6c2515e0 @ 440)
Sep 10 07:02:01 org.gnome.Shell.desktop[2322]: #2   562987934940 i   resource:///org/gnome/shell/ui/boxpointer.js:99 (7fcb6c20dee0 @ 112)
Sep 10 07:02:01 org.gnome.Shell.desktop[2322]: #3   5629879348a8 i   resource:///org/gnome/shell/ui/boxpointer.js:180 (7fcb6c212160 @ 12)
Sep 10 07:02:01 org.gnome.Shell.desktop[2322]: #4   562987934820 i   resource:///org/gnome/shell/ui/tweener.js:85 (7fcb6c6c88b0 @ 37)
Sep 10 07:02:01 org.gnome.Shell.desktop[2322]: #5   7ffc1dfbfbc0 b   resource:///org/gnome/gjs/modules/tweener/tweener.js:208 (7fcb6c6d14c0 @ 54)
Sep 10 07:02:01 org.gnome.Shell.desktop[2322]: #6   7ffc1dfbfd10 b   resource:///org/gnome/gjs/modules/tweener/tweener.js:342 (7fcb6c6d1550 @ 1742)
Sep 10 07:02:01 org.gnome.Shell.desktop[2322]: #7   7ffc1dfbfdc0 b   resource:///org/gnome/gjs/modules/tweener/tweener.js:355 (7fcb6c6d15e0 @ 100)
Sep 10 07:02:01 org.gnome.Shell.desktop[2322]: #8   7ffc1dfbfe50 b   resource:///org/gnome/gjs/modules/tweener/tweener.js:370 (7fcb6c6d1670 @ 10)
Sep 10 07:02:01 org.gnome.Shell.desktop[2322]: #9   7ffc1dfbfed0 I   resource:///org/gnome/gjs/modules/signals.js:142 (7fcb6c6cb670 @ 386)
Sep 10 07:02:01 org.gnome.Shell.desktop[2322]: #10   7ffc1dfbff80 b   resource:///org/gnome/shell/ui/tweener.js:201 (7fcb6c6cb160 @ 159)
Sep 10 07:02:01 org.gnome.Shell.desktop[2322]: #11   7ffc1dfc0020 b   resource:///org/gnome/shell/ui/tweener.js:172 (7fcb6c6cb040 @ 15)
```

Fixes #615