### PR TITLE
Update POT / PO files

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-10 11:13\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: Arabic\n"
@@ -10,25 +10,26 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
+"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
 "X-Generator: crowdin.com\n"
 "X-Crowdin-Project: gsconnect\n"
 "X-Crowdin-Language: ar\n"
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "معلومات التشفير"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "اقتران"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "إلغاء الاقتران"
 
@@ -39,8 +40,8 @@ msgstr "الاتصال بـ…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +69,16 @@ msgstr "المساعدة"
 msgid "Type a phone number or name"
 msgstr "اكتب رقم هاتف أو اسم"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "اكتب رسالة"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "إرسال رسالة"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "سطح المكتب"
 
@@ -115,7 +116,7 @@ msgstr "المشاركة"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "اﻷوامر"
 
@@ -286,11 +287,11 @@ msgid "Mute"
 msgstr "كتم"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "المراسة"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "محادثة جديدة"
 
@@ -328,8 +329,9 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr ""
 
@@ -341,7 +343,7 @@ msgstr ""
 msgid "Devices"
 msgstr ""
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr ""
 
@@ -357,7 +359,7 @@ msgstr ""
 msgid "This device is invisible to unpaired devices"
 msgstr ""
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr ""
 
@@ -376,7 +378,7 @@ msgid "User Menu"
 msgstr ""
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr ""
 
@@ -385,22 +387,22 @@ msgid "About GSConnect"
 msgstr ""
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr ""
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr ""
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr ""
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -412,7 +414,7 @@ msgstr[4] ""
 msgstr[5] ""
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr ""
 
@@ -421,190 +423,193 @@ msgstr ""
 msgid "Send To Mobile Device"
 msgstr ""
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr ""
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr ""
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr ""
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr ""
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr ""
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr ""
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr ""
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgstr ""
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr ""
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr ""
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr ""
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
 msgstr ""
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr ""
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr ""
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr ""
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr ""
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr ""
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr ""
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr ""
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr ""
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr ""
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr ""
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr ""
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr ""
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr ""
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
 msgstr ""
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr ""
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr ""
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr ""
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr ""
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr ""
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr ""
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr ""
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr ""
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr ""
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr ""
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr ""
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr ""
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr ""
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr ""
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr ""
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr ""
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr ""
 
@@ -685,7 +690,7 @@ msgstr ""
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr ""
@@ -919,7 +924,7 @@ msgid "%s・Home"
 msgstr ""
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr ""
@@ -957,7 +962,7 @@ msgstr ""
 msgid "You: %s"
 msgstr ""
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1059,4 +1064,3 @@ msgstr "الخدمة غير متاحة"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "فتح في المتصفح"
-

--- a/po/be.po
+++ b/po/be.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-13 23:34\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: Belarusian\n"
@@ -10,25 +10,27 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || n%10>=5 && n%10<=9 || n%100>=11 && n%100<=14 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || n%10>=5 && n%10<=9 || n"
+"%100>=11 && n%100<=14 ? 2 : 3);\n"
 "X-Generator: crowdin.com\n"
 "X-Crowdin-Project: gsconnect\n"
 "X-Crowdin-Language: be\n"
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Інфармацыя пра шыфраванне"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Спалучыць"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Разлучыць"
 
@@ -39,8 +41,8 @@ msgstr "Падлучыцца да…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +70,16 @@ msgstr "Даведка"
 msgid "Type a phone number or name"
 msgstr "Увесці нумар тэлефона або імя"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Напісаць паведамлене"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Адправіць паведамленне"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Камп'ютар"
 
@@ -115,7 +117,7 @@ msgstr "Абагульванне"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Каманды"
 
@@ -286,11 +288,11 @@ msgid "Mute"
 msgstr "Выключыць гук"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Паведамленні"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Новая размова"
 
@@ -328,8 +330,9 @@ msgstr "_Перайменаваць"
 msgid "Refresh"
 msgstr "Абнавіць"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Налады прылад"
 
@@ -341,7 +344,7 @@ msgstr "Рэдагаваць назву прылады"
 msgid "Devices"
 msgstr "Прылады"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Пошук прылад…"
 
@@ -357,7 +360,7 @@ msgstr "Уключана"
 msgid "This device is invisible to unpaired devices"
 msgstr "Гэта прылада нябачная для разлучаных прылад"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Знаходжанне адключана"
 
@@ -376,7 +379,7 @@ msgid "User Menu"
 msgstr "Меню карыстальніка"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Стварыць журнал для падтрымкі"
 
@@ -385,22 +388,22 @@ msgid "About GSConnect"
 msgstr "Пра GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Адправіць SMS"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Мабільныя прылады"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr "Уключыць"
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -410,7 +413,7 @@ msgstr[2] "%d падлучана"
 msgstr[3] "%d падлучана"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr "Выключыць"
 
@@ -419,190 +422,196 @@ msgstr "Выключыць"
 msgid "Send To Mobile Device"
 msgstr "Адправіць на мабільную прыладу"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Адкрыць"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Укл."
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Выкл."
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Адключана"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Задаць спалучэнні клавіш"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Задаць"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Увядзіце новыя спалучэнні, каб змяніць <b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
-msgstr "Націсніце Esc, каб скасаваць або Прабел, каб скінуць спалучэнне клавіш."
+msgstr ""
+"Націсніце Esc, каб скасаваць або Прабел, каб скінуць спалучэнне клавіш."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s ужо выкарыстоўваецца"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Паўнавартасная рэалізацыя KDE Connect для GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "Maksim Krapiŭka <metalomaniax@gmail.com>"
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
-msgstr "Паведамленні адладкі былі запісаны ў журнал. Зрабіце любыя крокі неабходныя для ўзнаўлення праблемы і затым праглядзіце журнал."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
+msgstr ""
+"Паведамленні адладкі былі запісаны ў журнал. Зрабіце любыя крокі неабходныя "
+"для ўзнаўлення праблемы і затым праглядзіце журнал."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Праверыць журнал"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Ноўтбук"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Смартфон"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Планшэт"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "Тэлебачанне"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Разлучана"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Адлучана"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Падлучана"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "Чаканне сэрвісу…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Справаздача"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Няўдача праверкі сапраўднасці"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Памылка сеткі"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Націсніце для дапамогі ў выпраўленні непаладак"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
 msgstr "Знаходжанне было адключана праз колькасць прылад у гэтай сетцы."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Націсніце для большай інфармацыі"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Набраць нумар"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Абагуліць файл"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr "Спіс даступных прылад"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr "Спіс усіх прылад"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr "Мэтавая прылада"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr "Змест паведамлення"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Адправіць апавяшчэнне"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr "Назва праграмы ў апавяшчэнні"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr "Змест апавяшчэння"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr "Значок апавяшчэння"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr "Ідэнтыфікатар апавяшчэння"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Фота"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Пінг"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Званок"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Абагуліць спасылку"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr "Паказаць версію праграмы"
 
@@ -683,7 +692,7 @@ msgstr "Запрасіць буфер абмену"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Невядомы кантакт"
@@ -917,7 +926,7 @@ msgid "%s・Home"
 msgstr "%s・Дом"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Адправіць у %s"
@@ -953,7 +962,7 @@ msgstr "Групавое паведамленне"
 msgid "You: %s"
 msgstr "Вы: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1051,4 +1060,3 @@ msgstr "Сэрвіс недаступны"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "Адкрыць у браўзеры"
-

--- a/po/ca.po
+++ b/po/ca.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-11 11:25\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: Catalan\n"
@@ -17,18 +17,18 @@ msgstr ""
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Informació de xifratge"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Aparella"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Desaparella"
 
@@ -39,8 +39,8 @@ msgstr "Connecta amb…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +68,16 @@ msgstr "Ajuda"
 msgid "Type a phone number or name"
 msgstr "Introduïu un número telefònic o un nom"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Escriviu un missatge"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Envia el missatge"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Ordinador d’escriptori"
 
@@ -115,7 +115,7 @@ msgstr "Compartició"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Ordres"
 
@@ -286,11 +286,11 @@ msgid "Mute"
 msgstr "Silencia"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Missatgeria"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Conversa nova"
 
@@ -328,8 +328,9 @@ msgstr "_Canvia el nom"
 msgid "Refresh"
 msgstr "Actualitza"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Paràmetres del mòbil"
 
@@ -341,7 +342,7 @@ msgstr "Edita el nom del dispositiu"
 msgid "Devices"
 msgstr "Dispositius"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "S’estan cercant dispositius…"
 
@@ -357,7 +358,7 @@ msgstr "Activa"
 msgid "This device is invisible to unpaired devices"
 msgstr "Aquest dispositiu és invisible als dispositius no aparellats"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr ""
 
@@ -376,7 +377,7 @@ msgid "User Menu"
 msgstr "Menú d’usuari"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Genera un registre d'assistència"
 
@@ -385,22 +386,22 @@ msgid "About GSConnect"
 msgstr "Quant al GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Envia un SMS"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Dispositius mòbils"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr "Activa"
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -408,7 +409,7 @@ msgstr[0] "%d connectat"
 msgstr[1] "%d connectats"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr "Desactiva"
 
@@ -417,191 +418,199 @@ msgstr "Desactiva"
 msgid "Send To Mobile Device"
 msgstr "Envia al dispositiu mòbil"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Obre"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr ""
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr ""
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Desactivat"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Definició d’una drecera"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Defineix"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr ""
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
-msgstr "Premeu Esc per a cancel·lar o Retrocés per a reinicialitzar la drecera de teclat."
+msgstr ""
+"Premeu Esc per a cancel·lar o Retrocés per a reinicialitzar la drecera de "
+"teclat."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s ja s’està fent servir"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Una implementació completa de KDE Connect per al GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
-msgstr "Adolfo Jayme Barrientos <fitojb@ubuntu.com>, 2019\n"
+msgstr ""
+"Adolfo Jayme Barrientos <fitojb@ubuntu.com>, 2019\n"
 "Marc Riera Irigoyen <marc.riera.irigoyen@gmail.com>, 2019"
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
-msgstr "S’estan registrant els missatges de depuració. Efectueu els passos necessaris per a reproduir un problema i, tot seguit, reviseu el registre."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
+msgstr ""
+"S’estan registrant els missatges de depuració. Efectueu els passos "
+"necessaris per a reproduir un problema i, tot seguit, reviseu el registre."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Mostra el registre"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Ordinador portàtil"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Telèfon intel·ligent"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Tauleta"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "Televisió"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Desaparellat"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Desconnectat"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Connectat"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "S’està esperant el servei…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr ""
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr ""
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Error de xarxa"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Ajuda per a resoldre el problema"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
 msgstr ""
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Més informació"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr ""
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Comparteix un fitxer"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr "Enumera els dispositius disponibles"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr "Enumera tots els dispositius"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr "Dispositiu de destinació"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr "Cos del missatge"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Envia una notificació"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr ""
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr ""
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr "Icona de notificació"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr ""
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr ""
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Comprovació de connectivitat"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Truca"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Comparteix un enllaç"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr ""
 
@@ -682,7 +691,7 @@ msgstr ""
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Contacte desconegut"
@@ -916,7 +925,7 @@ msgid "%s・Home"
 msgstr "%s・Particular"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Envia al %s"
@@ -950,7 +959,7 @@ msgstr ""
 msgid "You: %s"
 msgstr "Vós: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1033,7 +1042,9 @@ msgstr "GSConnect"
 #. TRANSLATORS: Chrome/Firefox WebExtension description
 #: webextension/gettext.js:29
 msgid "Share links with GSConnect, direct to the browser or by SMS."
-msgstr "Compartiu enllaços amb el GSConnect, directament al navegador o mitjançant SMS."
+msgstr ""
+"Compartiu enllaços amb el GSConnect, directament al navegador o mitjançant "
+"SMS."
 
 #. TRANSLATORS: WebExtension can't connect to GSConnect
 #: webextension/gettext.js:33
@@ -1044,4 +1055,3 @@ msgstr "El servei no està disponible"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "Obre al navegador"
-

--- a/po/cs.po
+++ b/po/cs.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-10 11:57\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: Czech\n"
@@ -17,18 +17,18 @@ msgstr ""
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Informace o šifrování"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Spárování"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Zrušit spárování"
 
@@ -39,8 +39,8 @@ msgstr "Připojit k…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +68,16 @@ msgstr "Nápověda"
 msgid "Type a phone number or name"
 msgstr "Napište telefonní číslo nebo jméno"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Napsat zprávu"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Odeslat zprávu"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Počítač"
 
@@ -115,7 +115,7 @@ msgstr "Sdílení"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Příkazy"
 
@@ -286,11 +286,11 @@ msgid "Mute"
 msgstr "Ztlumit"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Zasílání zpráv"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Nová konverzace"
 
@@ -328,8 +328,9 @@ msgstr "_Přejmenovat"
 msgid "Refresh"
 msgstr "Obnovit"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Nastavení telefonu"
 
@@ -341,7 +342,7 @@ msgstr "Upravit název zařízení"
 msgid "Devices"
 msgstr "Zařízení"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Vyhledávání zařízení…"
 
@@ -357,7 +358,7 @@ msgstr "Zapnout"
 msgid "This device is invisible to unpaired devices"
 msgstr "Toto zařízení je pro nespárovaná zařízení neviditelné"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Objevování vypnuto"
 
@@ -376,7 +377,7 @@ msgid "User Menu"
 msgstr "Uživatelská nabídka"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Vytvořit záznam událostí pro podporu"
 
@@ -385,22 +386,22 @@ msgid "About GSConnect"
 msgstr "O GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Poslat SMS"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Mobilní zařízení"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr "Zapnout"
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -410,7 +411,7 @@ msgstr[2] "%d připojených"
 msgstr[3] "%d připojených"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr "Vypnout"
 
@@ -419,190 +420,195 @@ msgstr "Vypnout"
 msgid "Send To Mobile Device"
 msgstr "Odeslat do mobilního zařízení"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Otevřít"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Zap."
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Vyp."
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Vypnuto"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Nastavení klávesové zkratky"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Nastavit"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Zadejte novou zkratku pro <b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgstr "Zrušíte stiskem Esc nebo pomocí Backspace vrátíte do původního stavu."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s už je používáno"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Úplná (re)implementace KDE Connect pro GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "Pavel Borecki <pavel.borecki@gmail.com>"
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
-msgstr "Ladící zprávy jsou zaznamenávány. Podnikněte kroky, potřebné pro vyvolání problému a pak si záznam prohlédněte."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
+msgstr ""
+"Ladící zprávy jsou zaznamenávány. Podnikněte kroky, potřebné pro vyvolání "
+"problému a pak si záznam prohlédněte."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Prohlédnout si záznam událostí"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Notebook"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Chytrý telefon"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Tablet"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "Televize"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Nespárováno"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Odpojeno"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Připojeno"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "Čeká se na službu…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Hlášení"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Ověření se nezdařilo"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Chyba sítě"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Kliknutím otevřete nápovědu pro odstraňování potíží"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
 msgstr "Kvůli velkému množství zařízení na této síti bylo objevování vypnuto."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Další informace získáte kliknutím"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Vytočit číslo"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Sdílet soubor"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr "Vypsat zařízení k dispozici"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr "Vypsat všechna zařízení"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr "Cílové zařízení"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr "Tělo zprávy"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Poslat oznámení"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr "Název oznamovací aplikace"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr "Tělo oznámení"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr "Ikona oznámení"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr "Identif. oznámení"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Fotka"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ping"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Vyzvánění"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Sdílet odkaz"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr "Zobrazit verzi vydání"
 
@@ -683,7 +689,7 @@ msgstr "Stahování schránky"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Neznámý kontakt"
@@ -917,7 +923,7 @@ msgid "%s・Home"
 msgstr "%s・Domů"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Poslat na %s"
@@ -953,7 +959,7 @@ msgstr "Skupinová zpráva"
 msgid "You: %s"
 msgstr "Vy: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1040,7 +1046,8 @@ msgstr "GSConnect"
 #. TRANSLATORS: Chrome/Firefox WebExtension description
 #: webextension/gettext.js:29
 msgid "Share links with GSConnect, direct to the browser or by SMS."
-msgstr "Sdílet odkazy pomocí GSConnect, přímo do prohlížeče nebo prostřednictvím SMS."
+msgstr ""
+"Sdílet odkazy pomocí GSConnect, přímo do prohlížeče nebo prostřednictvím SMS."
 
 #. TRANSLATORS: WebExtension can't connect to GSConnect
 #: webextension/gettext.js:33
@@ -1051,4 +1058,3 @@ msgstr "Služba nedostupná"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "Otevřít v prohlížeči"
-

--- a/po/da.po
+++ b/po/da.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-10 11:13\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: Danish\n"
@@ -17,18 +17,18 @@ msgstr ""
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Kryptering Info"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Par"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Unpair"
 
@@ -39,8 +39,8 @@ msgstr "Forbind til…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +68,16 @@ msgstr "Hjælp"
 msgid "Type a phone number or name"
 msgstr "Indtast et telefonnummer eller navn"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Skriv en meddelelse"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Send Meddelelse"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Stationær Computer"
 
@@ -115,7 +115,7 @@ msgstr "Deling"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Kommandoer"
 
@@ -286,11 +286,11 @@ msgid "Mute"
 msgstr "Lydløs"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Messaging"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Ny Samtale"
 
@@ -328,8 +328,9 @@ msgstr ""
 msgid "Refresh"
 msgstr "Opdater"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Mobile Indstillinger"
 
@@ -341,7 +342,7 @@ msgstr "Rediger Enheds Navn"
 msgid "Devices"
 msgstr "Enheder"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Søger efter enheder…"
 
@@ -357,7 +358,7 @@ msgstr "Aktiver"
 msgid "This device is invisible to unpaired devices"
 msgstr "Denne enhed er usynlig til ikke parret enheder"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Discovery Deaktiveret"
 
@@ -376,7 +377,7 @@ msgid "User Menu"
 msgstr "Bruger Menu"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Generere Underbygge Log"
 
@@ -385,22 +386,22 @@ msgid "About GSConnect"
 msgstr "Om GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Send SMS"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Mobil Enheder"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr ""
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -408,7 +409,7 @@ msgstr[0] "%d Tilsuttet"
 msgstr[1] "%d Tilsuttet"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr ""
 
@@ -417,190 +418,198 @@ msgstr ""
 msgid "Send To Mobile Device"
 msgstr "Send til Mobil Enhed"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Åbn"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Tænde"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Slukke"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Deaktiveret"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Indstil Genvej"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Indstil"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Indtast en ny genvej for at ændre <b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
-msgstr "Tryk på Esc at annullere eller backspace-nøgle for at nulstille tastaturgenvejen."
+msgstr ""
+"Tryk på Esc at annullere eller backspace-nøgle for at nulstille "
+"tastaturgenvejen."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s er allerede bliver brugt"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "En komplet KDE Connect implementering for GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "oversætter-kreditter"
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
-msgstr "Fejlmeddelelser er logges. Tage de nødvendige skridt til at reproducere et problem, og gennemgå loggen."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
+msgstr ""
+"Fejlmeddelelser er logges. Tage de nødvendige skridt til at reproducere et "
+"problem, og gennemgå loggen."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Gennemgå Loggen"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Bærbar"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Smartphone"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Tablet"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr ""
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Ikke parret"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Frakoblet"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Tilsluttet"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr ""
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Anmeld"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Godkendelsesfejl"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Netværks Fejl"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Klik for hjælp fejlfinding"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
-msgstr "Discovery er deaktiveret på grund af antallet af enheder på dette netværk."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
+msgstr ""
+"Discovery er deaktiveret på grund af antallet af enheder på dette netværk."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Klik for mere information"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Opkaldsnummer"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Del Fil"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr ""
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr ""
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr ""
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr ""
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Send Notifikation"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr ""
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr ""
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr ""
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr ""
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Foto"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ping"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Ring"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Del Link"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr ""
 
@@ -681,7 +690,7 @@ msgstr "Udklipsholder Trække"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Ukendt Kontakt"
@@ -915,7 +924,7 @@ msgid "%s・Home"
 msgstr "%s・Hjem"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Send til %s"
@@ -949,7 +958,7 @@ msgstr ""
 msgid "You: %s"
 msgstr "Du: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1043,4 +1052,3 @@ msgstr "Tjenesten er ikke tilgængelig"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "Åbn i browser"
-

--- a/po/de.po
+++ b/po/de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-10 11:34\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: German\n"
@@ -17,18 +17,18 @@ msgstr ""
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Verschlüsselunginfo"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Koppeln"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Entkoppeln"
 
@@ -39,8 +39,8 @@ msgstr "Verbinden mit …"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +68,16 @@ msgstr "Hilfe"
 msgid "Type a phone number or name"
 msgstr "Telefonnummer oder Name eingeben"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Eine Nachricht verfassen"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Nachricht senden"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Desktop"
 
@@ -115,7 +115,7 @@ msgstr "Teilen"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Befehle"
 
@@ -286,11 +286,11 @@ msgid "Mute"
 msgstr "Stumm schalten"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Nachrichten"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Neues Gespräch"
 
@@ -328,8 +328,9 @@ msgstr "_Umbenennen"
 msgid "Refresh"
 msgstr "Auffrischen"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Handy-Einstellungen"
 
@@ -341,7 +342,7 @@ msgstr "Gerätename bearbeiten"
 msgid "Devices"
 msgstr "Geräte"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Geräte werden gesucht…"
 
@@ -357,7 +358,7 @@ msgstr "Aktivieren"
 msgid "This device is invisible to unpaired devices"
 msgstr "Dieses Gerät ist für nicht gekoppelte Geräte unsichtbar"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Erkennen deaktiviert"
 
@@ -376,7 +377,7 @@ msgid "User Menu"
 msgstr "Benutzermenü"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Hilfeprotokoll generieren"
 
@@ -385,22 +386,22 @@ msgid "About GSConnect"
 msgstr "Über GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "SMS senden"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Mobile Geräte"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr "Aktivieren"
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -408,7 +409,7 @@ msgstr[0] "%d verbunden"
 msgstr[1] "%d verbunden"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr "Deaktivieren"
 
@@ -417,191 +418,202 @@ msgstr "Deaktivieren"
 msgid "Send To Mobile Device"
 msgstr "An Mobilgerät senden"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Öffnen"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "An"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Aus"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Deaktiviert"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Tastenkürzel festlegen"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Festlegen"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Ein neues Tastenkürzel eingeben, um <b>%s</b> zu Ändern"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
-msgstr "ESC zum Abbrechen oder die Rücktaste drücken, um das Tastenkürzel zurückzusetzen."
+msgstr ""
+"ESC zum Abbrechen oder die Rücktaste drücken, um das Tastenkürzel "
+"zurückzusetzen."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s ist schon vergeben"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Eine vollständige KDE-Connect-Implementierung für GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
-msgstr "taaem <taaem@mailbox.org>\n"
+msgstr ""
+"taaem <taaem@mailbox.org>\n"
 "Tobias Bannert <tobannert@gmail.com>"
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
-msgstr "Fehlersuchmeldungen werden protokolliert. Führen Sie alle erforderlichen Schritte aus, um ein Problem zu reproduzieren, und überprüfen Sie das Protokoll."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
+msgstr ""
+"Fehlersuchmeldungen werden protokolliert. Führen Sie alle erforderlichen "
+"Schritte aus, um ein Problem zu reproduzieren, und überprüfen Sie das "
+"Protokoll."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Protokoll überprüfen"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Laptop"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Smartphone"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Tablet"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "Fernseher"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Ungekoppelt"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Getrennt"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Verbunden"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "Warte auf Dienst…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Bericht"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Legitimerungsfehler"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Netzwerkfehler"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Für Hilfe bei der Fehlerbehebung hier klicken"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
-msgstr "Erkennen wurde deaktiviert, aufgrund der Anzahl an Geräten in diesem Netzwerk."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
+msgstr ""
+"Erkennen wurde deaktiviert, aufgrund der Anzahl an Geräten in diesem "
+"Netzwerk."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Für mehr Informationen klicken"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Nummer wählen"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Datei freigeben"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr "Alle verfügbaren Geräte anzeigen"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr "Alle Geräte anzeigen"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr "Zielgerät"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr "Nachrichtentext"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Benachrichtigung senden"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr ""
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr ""
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr "Benachrichtigungs-Symbol"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr "Mitteilungs-ID"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Foto"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ping"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Ring"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Verweis freigeben"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr "Neuste Version zeigen"
 
@@ -682,7 +694,7 @@ msgstr "Zwischenablage laden"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Unbekannter Kontakt"
@@ -916,7 +928,7 @@ msgid "%s・Home"
 msgstr "%s・Haus"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "An %s senden"
@@ -950,7 +962,7 @@ msgstr "Gruppennachricht"
 msgid "You: %s"
 msgstr "Sie: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1044,4 +1056,3 @@ msgstr "Dienst nicht verfügbar"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "Im Browser öffnen"
-

--- a/po/es.po
+++ b/po/es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-11 11:44\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: Spanish\n"
@@ -17,18 +17,18 @@ msgstr ""
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Información de cifrado"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Emparejamiento"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Desemparejar"
 
@@ -39,8 +39,8 @@ msgstr "Conectar con…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +68,16 @@ msgstr "Ayuda"
 msgid "Type a phone number or name"
 msgstr "Escriba un número telefónico o un nombre"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Escriba un mensaje"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Enviar mensaje"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Equipo de escritorio"
 
@@ -115,7 +115,7 @@ msgstr "Compartición"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Órdenes"
 
@@ -286,11 +286,11 @@ msgid "Mute"
 msgstr "Silenciar"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Mensajería"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Conversación nueva"
 
@@ -328,8 +328,9 @@ msgstr "_Cambiar nombre"
 msgid "Refresh"
 msgstr "Actualizar"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Configuración de móvil"
 
@@ -341,7 +342,7 @@ msgstr "Editar nombre de dispositivo"
 msgid "Devices"
 msgstr "Dispositivos"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Buscando dispositivos…"
 
@@ -357,7 +358,7 @@ msgstr "Activar"
 msgid "This device is invisible to unpaired devices"
 msgstr "Este dispositivo es invisible a dispositivos no emparejados"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Descubrimiento desactivado"
 
@@ -376,7 +377,7 @@ msgid "User Menu"
 msgstr "Menú de usuario"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Generar registro para asistencia"
 
@@ -385,22 +386,22 @@ msgid "About GSConnect"
 msgstr "Acerca de GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Enviar SMS"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Dispositivos móviles"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr "Encender"
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -408,7 +409,7 @@ msgstr[0] "%d conectado"
 msgstr[1] "%d conectados"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr "Apagar"
 
@@ -417,190 +418,198 @@ msgstr "Apagar"
 msgid "Send To Mobile Device"
 msgstr "Enviar a dispositivo móvil"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Abrir"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Activado"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Desactivado"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Desactivado"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Establecer atajo"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Establecer"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Digite un atajo nuevo para cambiar <b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
-msgstr "Oprima Esc para cancelar o Retroceso para restablecer el atajo de teclado."
+msgstr ""
+"Oprima Esc para cancelar o Retroceso para restablecer el atajo de teclado."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "Ya está utilizándose %s"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Una completa implementación de KDE Connect para GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "Adolfo Jayme Barrientos <fitojb@ubuntu.com>, 2018-2019"
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
-msgstr "Los mensajes de depuración están registrándose. Realice las acciones necesarias para reproducir un problema y, a continuación, revise el registro."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
+msgstr ""
+"Los mensajes de depuración están registrándose. Realice las acciones "
+"necesarias para reproducir un problema y, a continuación, revise el registro."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Revisar registro"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Equipo portátil"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Teléfono inteligente"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Tableta"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "Televisión"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Desemparejado"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Desconectado"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Conectado"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "Esperando el servicio…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Informe"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Fallo de autenticación"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Error de red"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Pulse para obtener información de solución de problemas"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
-msgstr "Se desactivó el descubrimiento debido al número de dispositivos presentes en esta red."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
+msgstr ""
+"Se desactivó el descubrimiento debido al número de dispositivos presentes en "
+"esta red."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Pulse para más información"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Marcar número"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Compartir archivo"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr "Enumerar dispositivos disponibles"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr "Enumerar todos los dispositivos"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr "Dispositivo de destino"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr "Cuerpo del mensaje"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Enviar notificación"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr ""
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr "Cuerpo de la notificación"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr "Icono de la notificación"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr "Identificador de la notificación"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Fotografía"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Prueba de conectividad"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Timbrar"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Compartir enlace"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr "Mostrar versión"
 
@@ -681,7 +690,7 @@ msgstr "Recepción desde portapapeles"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Contacto desconocido"
@@ -915,7 +924,7 @@ msgid "%s・Home"
 msgstr "%s・Residencial"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Enviar a %s"
@@ -949,7 +958,7 @@ msgstr "Mensaje grupal"
 msgid "You: %s"
 msgstr "Usted: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1032,7 +1041,8 @@ msgstr "GSConnect"
 #. TRANSLATORS: Chrome/Firefox WebExtension description
 #: webextension/gettext.js:29
 msgid "Share links with GSConnect, direct to the browser or by SMS."
-msgstr "Comparta enlaces con GSConnect, directamente al navegador o a través de SMS."
+msgstr ""
+"Comparta enlaces con GSConnect, directamente al navegador o a través de SMS."
 
 #. TRANSLATORS: WebExtension can't connect to GSConnect
 #: webextension/gettext.js:33
@@ -1043,4 +1053,3 @@ msgstr "Servicio no disponible"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "Abrir en el navegador"
-

--- a/po/et.po
+++ b/po/et.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-10 11:34\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: Estonian\n"
@@ -17,18 +17,18 @@ msgstr ""
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Krüpteeringu teave"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Paarita"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Eemalda paardumine"
 
@@ -39,8 +39,8 @@ msgstr "Ühendu…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +68,16 @@ msgstr "Abi"
 msgid "Type a phone number or name"
 msgstr "Kirjuta telefoninumber või nimi"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Kirjuta sõnum"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Saada sõnum"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Lauaarvuti"
 
@@ -115,7 +115,7 @@ msgstr "Jagamine"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Käsklused"
 
@@ -286,11 +286,11 @@ msgid "Mute"
 msgstr "Vaigista"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Sõnumside"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Uus vestlus"
 
@@ -328,8 +328,9 @@ msgstr "Nimeta ümber"
 msgid "Refresh"
 msgstr "Värskenda"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Mobiiliseaded"
 
@@ -341,7 +342,7 @@ msgstr "Muuda seadme nime"
 msgid "Devices"
 msgstr "Seadmed"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Seadmete otsimine…"
 
@@ -357,7 +358,7 @@ msgstr "Luba"
 msgid "This device is invisible to unpaired devices"
 msgstr "See seade on paardumata seadmetele nähtamatu"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Avastamine keelatud"
 
@@ -376,7 +377,7 @@ msgid "User Menu"
 msgstr "Kasutajamenüü"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Genereeri tugiteenusele logi"
 
@@ -385,22 +386,22 @@ msgid "About GSConnect"
 msgstr "GSConnecti teave"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Saada SMS"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Mobiilseadmed"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr "Lülita sisse"
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -408,7 +409,7 @@ msgstr[0] "%d ühendatud"
 msgstr[1] "%d ühendatud"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr "Lülita välja"
 
@@ -417,190 +418,196 @@ msgstr "Lülita välja"
 msgid "Send To Mobile Device"
 msgstr "Saada mobiilseadmesse"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Ava"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Sees"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Väljas"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Keelatud"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Määra otsetee"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Määra"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Sisesta <b>%s</b> muutmiseks uus otsetee"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
-msgstr "Vajuta tühistamiseks Esc või klaviatuuriotsetee lähtestamiseks Tagasilüke."
+msgstr ""
+"Vajuta tühistamiseks Esc või klaviatuuriotsetee lähtestamiseks Tagasilüke."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s on juba kasutusel"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Täielik KDE Connect'i teostus GNOMEle"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "Madis O, 2018."
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
-msgstr "Silumissõnumid logitakse. Teosta mistahes vajalikud sammud probleemi taasloomiseks, seejärel vaata logi üle."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
+msgstr ""
+"Silumissõnumid logitakse. Teosta mistahes vajalikud sammud probleemi "
+"taasloomiseks, seejärel vaata logi üle."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Vaata logi üle"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Sülearvuti"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Nutitelefon"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Tahvelarvuti"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "Televisioon"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Paaritamata"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Ühendus katkestatud"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Ühendatud"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "Teenuse ootamine…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Teata"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Autentimise viga"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Võrguviga"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Klõpsa, et saada veaotsingul abi"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
 msgstr "Avastamine on keelatud selles võrgus olevate seadmete arvu tõttu."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Klõpsa rohkema teabe saamiseks"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Helista telefoninumbrile"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Jaga faili"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr "Kuva saadaolevad seadmed"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr "Kuva kõik seadmed"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr "Sihtseade"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr "Sõnumi sisu"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Saada teade"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr "Teavitava rakenduse nimi"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr "Teate sisu"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr "Teate ikoon"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr "Teate ID"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Foto"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ping"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Helise"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Jaga linki"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr "Kuva väljalaskeversiooni"
 
@@ -681,7 +688,7 @@ msgstr "Lõikelaua vastuvõtmine"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Tundmatu kontakt"
@@ -915,7 +922,7 @@ msgid "%s・Home"
 msgstr "%s・Kodu"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Saada seadmesse %s"
@@ -949,7 +956,7 @@ msgstr "Grupisõnum"
 msgid "You: %s"
 msgstr "Sina: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1043,4 +1050,3 @@ msgstr "Teenus pole saadaval"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "Ava brauseris"
-

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-12 14:03\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: French\n"
@@ -17,18 +17,18 @@ msgstr ""
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Informations de chiffrement"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Associer"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Dissocier"
 
@@ -39,8 +39,8 @@ msgstr "Se connecter à…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +68,16 @@ msgstr "Aide"
 msgid "Type a phone number or name"
 msgstr "Taper un numéro de téléphone ou un nom"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Taper un message"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Envoyer le message"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Ordinateur de bureau"
 
@@ -115,7 +115,7 @@ msgstr "Partage"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Commandes"
 
@@ -286,11 +286,11 @@ msgid "Mute"
 msgstr "Mettre en sourdine"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Messagerie"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Nouvelle conversation"
 
@@ -328,8 +328,9 @@ msgstr "_Renommer"
 msgid "Refresh"
 msgstr "Rafraîchir"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Paramètres"
 
@@ -341,7 +342,7 @@ msgstr "Modifier le nom de l'appareil"
 msgid "Devices"
 msgstr "Appareils"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Recherche d'appareils…"
 
@@ -357,7 +358,7 @@ msgstr "Activer"
 msgid "This device is invisible to unpaired devices"
 msgstr "Cet appareil est invisible par les appareils non pairés"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Découverte désactivée"
 
@@ -376,7 +377,7 @@ msgid "User Menu"
 msgstr "Menu utilisateur"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Générer des logs pour le support"
 
@@ -385,22 +386,22 @@ msgid "About GSConnect"
 msgstr "À propos de GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Envoyer un SMS"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Appareils mobiles"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr ""
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -408,7 +409,7 @@ msgstr[0] "%d Connecté"
 msgstr[1] "%d Connectés"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr ""
 
@@ -417,190 +418,199 @@ msgstr ""
 msgid "Send To Mobile Device"
 msgstr "Envoyer vers l'appareil mobile"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Ouvrir"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Activé"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Désactivé"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Désactivé"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Définir un raccourci"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Définir"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Entrer un nouveau raccourci pour modifier <b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
-msgstr "Appuyez sur Echap pour annuler ou sur Retour Arrière pour réinitialiser le raccourci clavier."
+msgstr ""
+"Appuyez sur Echap pour annuler ou sur Retour Arrière pour réinitialiser le "
+"raccourci clavier."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s est déjà utilisé"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Une implémentation complète de KDE Connect pour GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "Mickaël Coiraton <mickael.coiraton@gmail.com>"
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
-msgstr "Les messages de dépannage sont enregistrés. Faites le nécessaire pour reproduire le problème puis vérifiez le fichier de log."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
+msgstr ""
+"Les messages de dépannage sont enregistrés. Faites le nécessaire pour "
+"reproduire le problème puis vérifiez le fichier de log."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Vérifier les logs"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Ordinateur portable"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Smartphone"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Tablette"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "Télévision"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Dissocié"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Déconnecté"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Connecté"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr ""
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Signaler"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Échec d'authentification"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Erreur réseau"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Cliquer pour l'aide de dépannage"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
-msgstr "La découverte a été désactivée en raison du nombre de périphériques sur ce réseau."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
+msgstr ""
+"La découverte a été désactivée en raison du nombre de périphériques sur ce "
+"réseau."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Cliquer pour plus d'informations"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Composer le numéro"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Partager un fichier"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr ""
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr ""
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr ""
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr ""
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Envoyer la notification"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr ""
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr ""
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr ""
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr ""
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr ""
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ping"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Faire sonner"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Partager un lien"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr ""
 
@@ -681,7 +691,7 @@ msgstr "Récupérer le presse-papiers"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Contact inconnu"
@@ -915,7 +925,7 @@ msgid "%s・Home"
 msgstr "%s・Maison"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Envoyer vers %s"
@@ -949,7 +959,7 @@ msgstr ""
 msgid "You: %s"
 msgstr "Vous: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1032,7 +1042,8 @@ msgstr "GSConnect"
 #. TRANSLATORS: Chrome/Firefox WebExtension description
 #: webextension/gettext.js:29
 msgid "Share links with GSConnect, direct to the browser or by SMS."
-msgstr "Partagez des liens avec GSConnect, directement vers le navigateur ou par SMS."
+msgstr ""
+"Partagez des liens avec GSConnect, directement vers le navigateur ou par SMS."
 
 #. TRANSLATORS: WebExtension can't connect to GSConnect
 #: webextension/gettext.js:33
@@ -1043,4 +1054,3 @@ msgstr "Service indisponible"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "Ouvrir dans le navigateur"
-

--- a/po/gl.po
+++ b/po/gl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-10 11:12\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: Galician\n"
@@ -17,18 +17,18 @@ msgstr ""
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Info de cifrado"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Enparellar"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Desemparellar"
 
@@ -39,8 +39,8 @@ msgstr "Conectar con…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +68,16 @@ msgstr "Axuda"
 msgid "Type a phone number or name"
 msgstr "Escriba o número de teléfono ou nome"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Escriba unha mensaxe"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Enviar mensaxe"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Escritorio"
 
@@ -115,7 +115,7 @@ msgstr "Compartindo"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Ordes"
 
@@ -286,11 +286,11 @@ msgid "Mute"
 msgstr "Silencio"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Mensaxes"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Nova conversa"
 
@@ -328,8 +328,9 @@ msgstr ""
 msgid "Refresh"
 msgstr "Actualizar"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Configuración móbil"
 
@@ -341,7 +342,7 @@ msgstr "Editar o nome do dispositivo"
 msgid "Devices"
 msgstr "Dispositivos"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Buscando dispositivos…"
 
@@ -357,7 +358,7 @@ msgstr "Activar"
 msgid "This device is invisible to unpaired devices"
 msgstr "Este dispositivo é invisíbel para dispositivos non emparellados"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Descuberta desactivada"
 
@@ -376,7 +377,7 @@ msgid "User Menu"
 msgstr "Menú do usuario"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Xerar o rexistro para asistencia"
 
@@ -385,22 +386,22 @@ msgid "About GSConnect"
 msgstr "Verbo de GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Enviar SMS"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Dispositivos móbiles"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr ""
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -408,7 +409,7 @@ msgstr[0] "%d Conectado"
 msgstr[1] "%d Conectados"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr ""
 
@@ -417,190 +418,196 @@ msgstr ""
 msgid "Send To Mobile Device"
 msgstr "Enviar a dispositivo móbil"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Abrir"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Aceso"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Apagado"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Desactivado"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Definir atallo"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Definir"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Escribir un novo atallo para cambiar<b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
-msgstr "Premer Esc para anular ou Retroceso para redefinir o atallo de teclado."
+msgstr ""
+"Premer Esc para anular ou Retroceso para redefinir o atallo de teclado."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s xa está en uso"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Unha implementación completa de KDE Connect para GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "tradutor"
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
-msgstr "Estanse a rexistrar as mensaxes de depuración. Faga o necesario para reproducir o problema e logo revise o rexistro."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
+msgstr ""
+"Estanse a rexistrar as mensaxes de depuración. Faga o necesario para "
+"reproducir o problema e logo revise o rexistro."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Revisar o rexistro"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Portátil"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Móbil"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Tableta"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr ""
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Desemparellado"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Desconectado"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Conectado"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr ""
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Informar"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Fallo de autenticación"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Erro de rede"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Prema para obter axuda de solucións"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
 msgstr "A descuberta desactivouse debido ao número de dispositivos nesta rede."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Premer para ter máis información"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Número en dial"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Compartir ficheiro"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr ""
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr ""
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr ""
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr ""
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Enviar a notificación"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr ""
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr ""
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr ""
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr ""
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Foto"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ping"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Timbre"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Compartir ligazón"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr ""
 
@@ -681,7 +688,7 @@ msgstr "Recoller no portapapeis"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Contacto descoñecido"
@@ -915,7 +922,7 @@ msgid "%s・Home"
 msgstr "%s・Casa"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Enviar a %s"
@@ -949,7 +956,7 @@ msgstr ""
 msgid "You: %s"
 msgstr "Vostede: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1032,7 +1039,8 @@ msgstr "GSConnect"
 #. TRANSLATORS: Chrome/Firefox WebExtension description
 #: webextension/gettext.js:29
 msgid "Share links with GSConnect, direct to the browser or by SMS."
-msgstr "Compartir ligazóns con GSConnect, directamente co navegador ou por SMS."
+msgstr ""
+"Compartir ligazóns con GSConnect, directamente co navegador ou por SMS."
 
 #. TRANSLATORS: WebExtension can't connect to GSConnect
 #: webextension/gettext.js:33
@@ -1043,4 +1051,3 @@ msgstr "Servizo non dispoñíbel"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "Abrir no navegador"
-

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-09-22 23:57+0200\n"
 "Last-Translator: Báthory Péter <bathory86p@gmail.com>\n"
 "Language-Team: \n"
@@ -19,18 +19,18 @@ msgstr ""
 "X-Generator: Poedit 2.2.1\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Titkosítási információ"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Párosítás"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Párosítás megszűntetése"
 
@@ -41,8 +41,8 @@ msgstr "Kapcsolódás egy eszközhöz…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -70,16 +70,16 @@ msgstr "Súgó"
 msgid "Type a phone number or name"
 msgstr "Adjon meg egy számot vagy nevet"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Írja be az üzenetet"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Üzenet küldése"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Asztali gép"
 
@@ -117,7 +117,7 @@ msgstr "Megosztás"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Parancsok"
 
@@ -288,11 +288,11 @@ msgid "Mute"
 msgstr "Némítás"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Üzenetküldés"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Új beszélgetés"
 
@@ -330,8 +330,9 @@ msgstr "_Átnevezés"
 msgid "Refresh"
 msgstr "Frissítés"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Mobil beállítások"
 
@@ -343,7 +344,7 @@ msgstr "Eszköz nevének szerkesztése"
 msgid "Devices"
 msgstr "Eszközök"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Eszközök keresése…"
 
@@ -359,7 +360,7 @@ msgstr "Engedélyez"
 msgid "This device is invisible to unpaired devices"
 msgstr "Ez az eszköz nem látható a párosítatlan eszközök számára"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Felderítés letiltva"
 
@@ -378,7 +379,7 @@ msgid "User Menu"
 msgstr "Felhasználói menü"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Naplófájl készítése terméktámogatáshoz"
 
@@ -387,22 +388,22 @@ msgid "About GSConnect"
 msgstr "A GSConnect névjegye"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "SMS küldése"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Mobil eszközök"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr "Bekapcsolás"
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -410,7 +411,7 @@ msgstr[0] "Egy eszköz csatlakoztatva"
 msgstr[1] "%d eszköz csatlakoztatva"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr "Kikapcsolás"
 
@@ -419,41 +420,41 @@ msgstr "Kikapcsolás"
 msgid "Send To Mobile Device"
 msgstr "Küldés mobil eszközre"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Megnyitás"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Be"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Ki"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Letiltva"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Gyorsbillentyű beállítása"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Kiválasztás"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "<b>%s</b> megváltoztatásához adj meg egy új gyorsbillentyűt"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgstr ""
 "A megszakításhoz nyomj Esc gombot, vagy Backspace-t a gyorsbillentyű "
@@ -461,21 +462,21 @@ msgstr ""
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s már használatban van"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Teljes KDE Connect implementáció GNOME-hoz"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "Báthory Péter <bathory86p@gmail.com>"
 
-#: src/preferences/service.js:430
+#: src/preferences/service.js:426
 msgid ""
 "Debug messages are being logged. Take any steps necessary to reproduce a "
 "problem then review the log."
@@ -483,133 +484,133 @@ msgstr ""
 "A hibakeresési üzenetek naplózásra kerülnek. Csinálj a hiba reprodukálásához "
 "szükséges lépést, majd nézd át a naplót."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Napló átnézése"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Laptop"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Okostelefon"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Táblagép"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "TV"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Nincs párosítva"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Nincs csatlakoztatva"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Csatlakoztatva"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "Várakozás a szolgáltatásra…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Jelentés"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Hitelesítési hiba"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Hálózati hiba"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Kattintson ide, hogy segítséget kapj a hibaelhárításhoz"
 
-#: src/service/daemon.js:599
+#: src/service/daemon.js:595
 msgid ""
 "Discovery has been disabled due to the number of devices on this network."
 msgstr "A felderítés le lett tiltva a hálózaton lévő eszközök száma miatt."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "További információért kattintson ide"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Telefonszám hívása"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Fájl megosztása"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr "Elérhető eszközök listázása"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr "Összes eszköz listázása"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr "Cél eszköz"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr "Üzenet szövege"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Értesítés küldése"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr "Értesítés alkalmazásnév"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr "Értesítés törzs"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr "Értesítés ikon"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr "Értesítés ID"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Fotó"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ping"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Csörgetés"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Hivatkozás megosztása"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr "Kiadás verziószám megjelenítése"
 
@@ -690,7 +691,7 @@ msgstr "Vágólap fogadás"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Ismeretlen névjegy"
@@ -925,7 +926,7 @@ msgid "%s・Home"
 msgstr "%s・Otthoni"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Küldés neki: %s"
@@ -959,7 +960,7 @@ msgstr "Csoportos üzenet"
 msgid "You: %s"
 msgstr "Te: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"

--- a/po/it.po
+++ b/po/it.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-11 06:25\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: Italian\n"
@@ -17,18 +17,18 @@ msgstr ""
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Informazioni di criptazione"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Accoppia"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Disaccoppia"
 
@@ -39,8 +39,8 @@ msgstr "Connetti a…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +68,16 @@ msgstr "Aiuto"
 msgid "Type a phone number or name"
 msgstr "Digita un numero di telefono o un nome"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Digita un messaggio"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Invia un messaggio"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Desktop"
 
@@ -115,7 +115,7 @@ msgstr "Condivisione"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Comandi"
 
@@ -286,11 +286,11 @@ msgid "Mute"
 msgstr "Silenzia"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Messaggi"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Nuova conversazione"
 
@@ -328,8 +328,9 @@ msgstr "_Rinomina"
 msgid "Refresh"
 msgstr "Aggiorna"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Impostazioni mobile"
 
@@ -341,7 +342,7 @@ msgstr "Modifica il nome del dispositivo"
 msgid "Devices"
 msgstr "Dispositivi"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Ricerca dei dispositivi…"
 
@@ -357,7 +358,7 @@ msgstr "Abilita"
 msgid "This device is invisible to unpaired devices"
 msgstr "Questo dispositivo è invisibile ai dispositivi disaccoppiati"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Ricerca disattiva"
 
@@ -376,7 +377,7 @@ msgid "User Menu"
 msgstr "Menu utente"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Genera log di supporto"
 
@@ -385,22 +386,22 @@ msgid "About GSConnect"
 msgstr "Informazioni su GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Invia SMS"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Dispositivi mobili"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr "Attiva"
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -408,7 +409,7 @@ msgstr[0] "%d connesso"
 msgstr[1] "%d connessi"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr "Disattiva"
 
@@ -417,190 +418,197 @@ msgstr "Disattiva"
 msgid "Send To Mobile Device"
 msgstr "Invia al dispositivo mobile"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Apri"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "On"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Off"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Disabilitato"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Imposta scorciatoia"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Imposta"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Inserisci una nuova scorciatoia per <b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgstr "Premi ESC per annullare o Backspace per ripristinare la scorciatoia."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s già in uso"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Un'implementazione completa di KDE Connect per GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "Jimmy Scionti <jimmy.scionti@gmail.com>"
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
-msgstr "I messaggi di debug vengono registrati. Adotta tutte le misure necessarie per riprodurre un problema, quindi rivedi il registro."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
+msgstr ""
+"I messaggi di debug vengono registrati. Adotta tutte le misure necessarie "
+"per riprodurre un problema, quindi rivedi il registro."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Log delle Revisioni"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Laptop"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Smartphone"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Tablet"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "Televisione"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Disaccoppiato"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Disconnesso"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Connesso"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "In attesa del servizio…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Segnalazione"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Autenticazione fallita"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Errore di rete"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Click per la risoluzione del problema"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
-msgstr "La ricerca è stata disattivata a causa dell'elevato numero di dispositivi nella rete."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
+msgstr ""
+"La ricerca è stata disattivata a causa dell'elevato numero di dispositivi "
+"nella rete."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Click per altre informazioni"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Componi numero"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Invia file"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr "Elenco dei dispositivi disponibili"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr "Elenco di tutti i dispositivi"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr "Dispositivo di destinazione"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr "Corpo del messaggio"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Invia notifica"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr "Nome app di notifica"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr "Corpo della notifica"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr "Icona di notifica"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr "ID della notifica"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Foto"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ping"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Squilla"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Condividi collegamento"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr "Mostrare versione di rilascio"
 
@@ -681,7 +689,7 @@ msgstr "Ricevi appunti"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Contatto sconosciuto"
@@ -915,7 +923,7 @@ msgid "%s・Home"
 msgstr "%s・Casa"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Invia a %s"
@@ -949,7 +957,7 @@ msgstr "Messaggio di gruppo"
 msgid "You: %s"
 msgstr "Tu: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1032,7 +1040,8 @@ msgstr "GSConnect"
 #. TRANSLATORS: Chrome/Firefox WebExtension description
 #: webextension/gettext.js:29
 msgid "Share links with GSConnect, direct to the browser or by SMS."
-msgstr "Condividi collegamenti con GSConnect, direttamente nel browser o via SMS."
+msgstr ""
+"Condividi collegamenti con GSConnect, direttamente nel browser o via SMS."
 
 #. TRANSLATORS: WebExtension can't connect to GSConnect
 #: webextension/gettext.js:33
@@ -1043,4 +1052,3 @@ msgstr "Servizio non disponibile"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "Apri nel browser"
-

--- a/po/lt.po
+++ b/po/lt.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-25 19:04\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: Lithuanian\n"
@@ -10,25 +10,26 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && (n%100>19 || n%100<11) ? 0 : (n%10>=2 && n%10<=9) && (n%100>19 || n%100<11) ? 1 : n%1!=0 ? 2: 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && (n%100>19 || n%100<11) ? 0 : (n"
+"%10>=2 && n%10<=9) && (n%100>19 || n%100<11) ? 1 : n%1!=0 ? 2: 3);\n"
 "X-Generator: crowdin.com\n"
 "X-Crowdin-Project: gsconnect\n"
 "X-Crowdin-Language: lt\n"
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Šifravimo informacija"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Suporuoti"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Panaikinti suporavimą"
 
@@ -39,8 +40,8 @@ msgstr "Prisijungti prie…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +69,16 @@ msgstr "Žinynas"
 msgid "Type a phone number or name"
 msgstr "Įrašykite telefono numerį ar vardą"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Rašyti žinutę"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Siųsti žinutę"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Stalinis kompiuteris"
 
@@ -115,7 +116,7 @@ msgstr "Bendrinimas"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Komandos"
 
@@ -286,11 +287,11 @@ msgid "Mute"
 msgstr "Nutildyti"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Susirašinėjimai"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Naujas pokalbis"
 
@@ -328,8 +329,9 @@ msgstr "Pe_rvadinti"
 msgid "Refresh"
 msgstr "Įkelti iš naujo"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Mobiliųjų nustatymai"
 
@@ -341,7 +343,7 @@ msgstr "Taisyti įrenginio pavadinimą"
 msgid "Devices"
 msgstr "Įrenginiai"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Ieškoma įrenginių…"
 
@@ -357,7 +359,7 @@ msgstr "Įjungti"
 msgid "This device is invisible to unpaired devices"
 msgstr "Šis įrenginys yra nematomas nesuporuotiems įrenginiams"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Aptikimas išjungtas"
 
@@ -376,7 +378,7 @@ msgid "User Menu"
 msgstr "Naudotojo meniu"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Generuoti palaikymo žurnalą"
 
@@ -385,22 +387,22 @@ msgid "About GSConnect"
 msgstr "Apie GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Siųsti SMS"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Mobilieji įrenginiai"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr "Įjungti"
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -410,7 +412,7 @@ msgstr[2] "%d prijungtų"
 msgstr[3] "%d prijungtas"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr "Išjungti"
 
@@ -419,190 +421,197 @@ msgstr "Išjungti"
 msgid "Send To Mobile Device"
 msgstr "Siųsti į mobilųjį įrenginį"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Atverti"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Įjungta"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Išjungta"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Išjungta"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Nustatykite trumpinį"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Nustatyti"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Norėdami pakeisti<b>%s</b>, įveskite naują trumpinį"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
-msgstr "Norėdami atsisakyti, paspauskite Grįžimo (Esc) klavišą arba Naikinimo (Backspace) klavišą, norėdami atstatyti trumpinį."
+msgstr ""
+"Norėdami atsisakyti, paspauskite Grįžimo (Esc) klavišą arba Naikinimo "
+"(Backspace) klavišą, norėdami atstatyti trumpinį."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s jau yra naudojamas"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Pilnas KDE Connect įgyvendinimas, skirtas GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "Moo"
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
-msgstr "Derinimo pranešimai yra registruojami. Atlikite reikiamus veiksmus, kad pakartotumėte problemą, o tuomet peržiūrėkite žurnalą."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
+msgstr ""
+"Derinimo pranešimai yra registruojami. Atlikite reikiamus veiksmus, kad "
+"pakartotumėte problemą, o tuomet peržiūrėkite žurnalą."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Peržiūrėti žurnalą"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Nešiojamas kompiuteris"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Išmanusis telefonas"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Planšetė"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "Televizija"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Nebesuporuotas"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Atjungtas"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Prijungtas"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "Laukiama paslaugos…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Ataskaita"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Tapatybės nustatymo nesėkmė"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Tinklo klaida"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Spustelėkite, norėdami šalinti nesklandumus"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
 msgstr "Aptikimas buvo išjungtas dėl šiame tinkle esančių įrenginių skaičiaus."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Spustelėkite išsamesnei informacijai"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Rinkti numerį"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Bendrinti failą"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr "Išvardyti prieinamus įrenginius"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr "Išvardyti visus įrenginius"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr "Paskirties įrenginys"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr "Pagrindinė žinutės dalis"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Siųsti pranešimą"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr "Pranešimo programėlės pavadinimas"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr "Pagrindinė pranešimo dalis"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr "Pranešimo piktograma"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr "Pranešimo ID"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Nuotrauka"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ryšio patikrinimas"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Rasti telefoną"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Bendrinti nuorodą"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr "Rodyti laidos versiją"
 
@@ -683,7 +692,7 @@ msgstr "Gauti iškaprinės turinį"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Nežinomas adresatas"
@@ -917,7 +926,7 @@ msgid "%s・Home"
 msgstr "%s・Namų"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Siųsti %s"
@@ -953,7 +962,7 @@ msgstr "Grupės žinutė"
 msgid "You: %s"
 msgstr "Jūs: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1040,7 +1049,9 @@ msgstr "GSConnect"
 #. TRANSLATORS: Chrome/Firefox WebExtension description
 #: webextension/gettext.js:29
 msgid "Share links with GSConnect, direct to the browser or by SMS."
-msgstr "Bendrinti nuorodas, naudojant GSConnect, tiesiogiai į naršyklę ar per SMS žinutę."
+msgstr ""
+"Bendrinti nuorodas, naudojant GSConnect, tiesiogiai į naršyklę ar per SMS "
+"žinutę."
 
 #. TRANSLATORS: WebExtension can't connect to GSConnect
 #: webextension/gettext.js:33
@@ -1051,4 +1062,3 @@ msgstr "Paslauga neprieinama"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "Atverti naršyklėje"
-

--- a/po/nl_BE.po
+++ b/po/nl_BE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2018-11-21 19:57+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
 "Language-Team: Dutch <vistausss@outlook.com>\n"
@@ -19,18 +19,18 @@ msgstr ""
 "X-Generator: Poedit 2.1.1\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Encryptie-info"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Koppel aan"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Koppel af"
 
@@ -41,8 +41,8 @@ msgstr "Verbind met…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -71,17 +71,17 @@ msgstr "Hulp"
 msgid "Type a phone number or name"
 msgstr "Typ een telefoonnummer of naam"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Typ een bericht"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 #, fuzzy
 msgid "Send Message"
 msgstr "Nieuw bericht"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Desktop"
 
@@ -119,7 +119,7 @@ msgstr "Deling"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Commando's"
 
@@ -296,11 +296,11 @@ msgid "Mute"
 msgstr "Toedoen"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Berichten"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 #, fuzzy
 msgid "New Conversation"
 msgstr "Kies een conversatie"
@@ -342,8 +342,9 @@ msgstr ""
 msgid "Refresh"
 msgstr "Herlaad"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "GSM-instellingen"
 
@@ -356,7 +357,7 @@ msgstr ""
 msgid "Devices"
 msgstr "Naar GSM"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr ""
 
@@ -373,7 +374,7 @@ msgstr "Tablet"
 msgid "This device is invisible to unpaired devices"
 msgstr ""
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Herkenning uitgeschakeld"
 
@@ -392,7 +393,7 @@ msgid "User Menu"
 msgstr "Gebruikersmenu"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr ""
 
@@ -402,22 +403,22 @@ msgid "About GSConnect"
 msgstr "GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Verzend SMS"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "GSM's"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr ""
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -425,7 +426,7 @@ msgstr[0] "%d verbonden"
 msgstr[1] "%d verbonden"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr ""
 
@@ -434,208 +435,208 @@ msgstr ""
 msgid "Send To Mobile Device"
 msgstr "Verzend naar GSM"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Open"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Aan"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Uit"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Uitgeschakeld"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Stel sneltoets in"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Stel in"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Voer een nieuwe sneltoets in voor het wijzigen van <b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgstr ""
 "Druk op Esc om te annuleren of op Backspace om de sneltoets terug te zetten."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s is al in gebruik"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Volledige KDE Connect-implementatie voor GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "Heimen Stoffels"
 
-#: src/preferences/service.js:430
+#: src/preferences/service.js:426
 msgid ""
 "Debug messages are being logged. Take any steps necessary to reproduce a "
 "problem then review the log."
 msgstr ""
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr ""
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Laptop"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Smartphone"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Tablet"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 #, fuzzy
 msgid "Television"
 msgstr "Telefonie"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 #, fuzzy
 msgid "Unpaired"
 msgstr "Koppel af"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 #, fuzzy
 msgid "Disconnected"
 msgstr "Toestel is niet geconnecteerd"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 #, fuzzy
 msgid "Connected"
 msgstr "Verbind"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr ""
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Rapporteer"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Authenticatieprobleem"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Netwerkfout"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Klik voor probleemoplossing"
 
-#: src/service/daemon.js:599
+#: src/service/daemon.js:595
 msgid ""
 "Discovery has been disabled due to the number of devices on this network."
 msgstr ""
 "Herkenning is uitgeschakeld vanwege het aantal toestellen op dit netwerk."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Klik voor meer informatie"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Telefoonoproep"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Deel bestand"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 #, fuzzy
 msgid "List available devices"
 msgstr "Onbeschikbaar"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 #, fuzzy
 msgid "List all devices"
 msgstr "GSM's"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 #, fuzzy
 msgid "Target Device"
 msgstr "Naar GSM"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 #, fuzzy
 msgid "Message Body"
 msgstr "Nieuw bericht"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Verzendnotificatie"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 #, fuzzy
 msgid "Notification App Name"
 msgstr "Notificaties"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 #, fuzzy
 msgid "Notification Body"
 msgstr "Notificaties"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 #, fuzzy
 msgid "Notification Icon"
 msgstr "Notificaties"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 #, fuzzy
 msgid "Notification ID"
 msgstr "Notificaties"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr ""
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ping"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 #, fuzzy
 msgid "Ring"
 msgstr "Lokaliseer"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Deel link"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 #, fuzzy
 msgid "Show release version"
 msgstr "Kies een conversatie"
@@ -717,7 +718,7 @@ msgstr "Haal klembord op"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Onbekend contact"
@@ -955,7 +956,7 @@ msgid "%s・Home"
 msgstr "%s・Thuis"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Verzend naar %s"
@@ -990,7 +991,7 @@ msgstr "Nieuw bericht"
 msgid "You: %s"
 msgstr ""
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"

--- a/po/nl_NL.po
+++ b/po/nl_NL.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-05-26 12:20+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
 "Language-Team: Dutch <vistausss@outlook.com>\n"
@@ -19,18 +19,18 @@ msgstr ""
 "X-Generator: Poedit 2.1.1\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Versleutelingsinformatie"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Aankoppelen"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Ontkoppelen"
 
@@ -41,8 +41,8 @@ msgstr "Verbinden met…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -70,16 +70,16 @@ msgstr "Hulp"
 msgid "Type a phone number or name"
 msgstr "Typ een telefoonnummer of naam"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Typ een bericht"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Bericht versturen"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Bureaubladcomputer"
 
@@ -117,7 +117,7 @@ msgstr "Delen"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Opdrachten"
 
@@ -293,11 +293,11 @@ msgid "Mute"
 msgstr "Dempen"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Berichten"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Nieuw gesprek"
 
@@ -336,8 +336,9 @@ msgstr ""
 msgid "Refresh"
 msgstr "Verversen"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Mobiele instellingen"
 
@@ -349,7 +350,7 @@ msgstr "Apparaatnaam bewerken"
 msgid "Devices"
 msgstr "Apparaten"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Bezig met zoeken naar apparaten…"
 
@@ -365,7 +366,7 @@ msgstr "Inschakelen"
 msgid "This device is invisible to unpaired devices"
 msgstr "Dit apparaat is onzichtbaar voor niet-gekoppelde apparaten"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Herkenning uitgeschakeld"
 
@@ -384,7 +385,7 @@ msgid "User Menu"
 msgstr "Gebruikersmenu"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Ondersteuningslogboek genereren"
 
@@ -393,22 +394,22 @@ msgid "About GSConnect"
 msgstr "Over GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "SMS versturen"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Mobiele apparaten"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr ""
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -416,7 +417,7 @@ msgstr[0] "%d verbonden"
 msgstr[1] "%d verbonden"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr ""
 
@@ -425,41 +426,41 @@ msgstr ""
 msgid "Send To Mobile Device"
 msgstr "Versturen naar mobiel apparaat"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Openen"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Aan"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Uit"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Uitgeschakeld"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Sneltoets instellen"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Instellen"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Voer een nieuwe sneltoets in om <b>%s</b> te wijzigen"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgstr ""
 "Druk op Esc om te annuleren of Backspace om de standaard sneltoets te "
@@ -467,21 +468,21 @@ msgstr ""
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s wordt al gebruikt"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Een volledige KDE Connect-implementatie voor GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "Heimen Stoffels"
 
-#: src/preferences/service.js:430
+#: src/preferences/service.js:426
 msgid ""
 "Debug messages are being logged. Take any steps necessary to reproduce a "
 "problem then review the log."
@@ -489,144 +490,144 @@ msgstr ""
 "Foutopsporingsberichten worden gelogd. Doe alles wat nodig is om het "
 "probleem aan te tonen en kijk dan het logbestand na."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Logbestand nakijken"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Laptop"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Smartphone"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Tablet"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 #, fuzzy
 msgid "Television"
 msgstr "Telefoon"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Ontkoppeld"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Niet verbonden"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Verbonden"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 #, fuzzy
 msgid "Waiting for service…"
 msgstr "Bezig met zoeken naar apparaten…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Rapporteren"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Authenticatiefout"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Netwerkfout"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Klik voor probleemoplossing"
 
-#: src/service/daemon.js:599
+#: src/service/daemon.js:595
 msgid ""
 "Discovery has been disabled due to the number of devices on this network."
 msgstr ""
 "Herkenning is uitgeschakeld vanwege het aantal apparaten op dit netwerk."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Klik voor meer informatie"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Nummer bellen"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Bestand delen"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 #, fuzzy
 msgid "List available devices"
 msgstr "Niet beschikbaar"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 #, fuzzy
 msgid "List all devices"
 msgstr "Mobiele apparaten"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 #, fuzzy
 msgid "Target Device"
 msgstr "Naar apparaat"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 #, fuzzy
 msgid "Message Body"
 msgstr "Nieuw bericht"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Melding versturen"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 #, fuzzy
 msgid "Notification App Name"
 msgstr "Meldingen"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 #, fuzzy
 msgid "Notification Body"
 msgstr "Meldingen"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 #, fuzzy
 msgid "Notification Icon"
 msgstr "Meldingen"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 #, fuzzy
 msgid "Notification ID"
 msgstr "Meldingen"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Foto"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ping"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Over laten gaan"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Link delen"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr ""
 
@@ -707,7 +708,7 @@ msgstr "Klembord ophalen"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Onbekende contactpersoon"
@@ -944,7 +945,7 @@ msgid "%s・Home"
 msgstr "%s・Thuis"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Versturen naar %s"
@@ -979,7 +980,7 @@ msgstr "Nieuw bericht"
 msgid "You: %s"
 msgstr "Jij: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"

--- a/po/org.gnome.Shell.Extensions.GSConnect.pot
+++ b/po/org.gnome.Shell.Extensions.GSConnect.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,18 +19,18 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr ""
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr ""
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr ""
 
@@ -41,8 +41,8 @@ msgstr ""
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -70,16 +70,16 @@ msgstr ""
 msgid "Type a phone number or name"
 msgstr ""
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr ""
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr ""
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr ""
 
@@ -117,7 +117,7 @@ msgstr ""
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr ""
 
@@ -288,11 +288,11 @@ msgid "Mute"
 msgstr ""
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr ""
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr ""
 
@@ -330,8 +330,9 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr ""
 
@@ -343,7 +344,7 @@ msgstr ""
 msgid "Devices"
 msgstr ""
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr ""
 
@@ -359,7 +360,7 @@ msgstr ""
 msgid "This device is invisible to unpaired devices"
 msgstr ""
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr ""
 
@@ -378,7 +379,7 @@ msgid "User Menu"
 msgstr ""
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr ""
 
@@ -387,22 +388,22 @@ msgid "About GSConnect"
 msgstr ""
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr ""
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr ""
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr ""
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -410,7 +411,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr ""
 
@@ -419,193 +420,193 @@ msgstr ""
 msgid "Send To Mobile Device"
 msgstr ""
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr ""
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr ""
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr ""
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr ""
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr ""
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr ""
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr ""
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgstr ""
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr ""
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr ""
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr ""
 
-#: src/preferences/service.js:430
+#: src/preferences/service.js:426
 msgid ""
 "Debug messages are being logged. Take any steps necessary to reproduce a "
 "problem then review the log."
 msgstr ""
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr ""
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr ""
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr ""
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr ""
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr ""
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr ""
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr ""
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr ""
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr ""
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr ""
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr ""
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr ""
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr ""
 
-#: src/service/daemon.js:599
+#: src/service/daemon.js:595
 msgid ""
 "Discovery has been disabled due to the number of devices on this network."
 msgstr ""
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr ""
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr ""
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr ""
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr ""
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr ""
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr ""
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr ""
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr ""
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr ""
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr ""
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr ""
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr ""
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr ""
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr ""
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr ""
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr ""
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr ""
 
@@ -686,7 +687,7 @@ msgstr ""
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr ""
@@ -920,7 +921,7 @@ msgid "%s・Home"
 msgstr ""
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr ""
@@ -954,7 +955,7 @@ msgstr ""
 msgid "You: %s"
 msgstr ""
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"

--- a/po/pl.po
+++ b/po/pl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-10 11:34\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: Polish\n"
@@ -10,25 +10,27 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n"
+"%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
+"%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 "X-Generator: crowdin.com\n"
 "X-Crowdin-Project: gsconnect\n"
 "X-Crowdin-Language: pl\n"
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Informacje o szyfrowaniu"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Powiąż"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Odwiąż"
 
@@ -39,8 +41,8 @@ msgstr "Połącz z…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +70,16 @@ msgstr "Pomoc"
 msgid "Type a phone number or name"
 msgstr "Numer telefonu lub nazwa kontaktu"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Napisz wiadomość"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Wysyła wiadomość"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Komputer stacjonarny"
 
@@ -115,7 +117,7 @@ msgstr "Udostępnianie"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Polecenia"
 
@@ -286,11 +288,11 @@ msgid "Mute"
 msgstr "Wycisz"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Wiadomości"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Nowa rozmowa"
 
@@ -328,8 +330,9 @@ msgstr "_Zmień nazwę"
 msgid "Refresh"
 msgstr "Odśwież"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Ustawienia urządzeń mobilnych"
 
@@ -341,7 +344,7 @@ msgstr "Modyfikuje nazwę urządzenia"
 msgid "Devices"
 msgstr "Urządzenia"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Wyszukiwanie urządzeń…"
 
@@ -357,7 +360,7 @@ msgstr "Włącz"
 msgid "This device is invisible to unpaired devices"
 msgstr "To urządzenie jest niewidoczne dla niepowiązanych urządzeń"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Wykrywanie jest wyłączone"
 
@@ -376,7 +379,7 @@ msgid "User Menu"
 msgstr "Menu użytkownika"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Utwórz dziennik wsparcia"
 
@@ -385,22 +388,22 @@ msgid "About GSConnect"
 msgstr "O programie"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Wyślij SMS"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Urządzenia mobilne"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr "Włącz"
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -410,7 +413,7 @@ msgstr[2] "%d połączonych urządzeń"
 msgstr[3] "%d połączonych urządzeń"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr "Wyłącz"
 
@@ -419,192 +422,198 @@ msgstr "Wyłącz"
 msgid "Send To Mobile Device"
 msgstr "Wyślij na urządzenie mobilne"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Otwórz"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Włączone"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Wyłączone"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Wyłączone"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Ustawienie skrótu"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Ustaw"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Proszę wprowadzić nowy skrót, aby zmienić „<b>%s</b>”"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgstr "Klawisz Esc anuluje, a Backspace przywróci skrót klawiszowy."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s jest już używane"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Pełna implementacja KDE Connect dla środowiska GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
-msgstr "Adrian Kryński <krynkaxd@gmail.com>, 2017\n"
+msgstr ""
+"Adrian Kryński <krynkaxd@gmail.com>, 2017\n"
 "Piotr Drąg <piotrdrag@gmail.com>, 2018-2019\n"
 "Aviary.pl <community-poland@mozilla.org>, 2018-2019"
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
-msgstr "Komunikaty debugowania są zapisywane w dzienniku. Proszę podjąć działania niezbędne do powtórzenia problemu, a następnie przejrzeć dziennik."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
+msgstr ""
+"Komunikaty debugowania są zapisywane w dzienniku. Proszę podjąć działania "
+"niezbędne do powtórzenia problemu, a następnie przejrzeć dziennik."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Przejrzyj dziennik"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Laptop"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Smartfon"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Tablet"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "Telewizor"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Niepowiązane"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Rozłączone"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Połączone"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "Oczekiwanie na usługę…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Zgłoś"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Niepowodzenie uwierzytelnienia"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Błąd sieci"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Uzyskaj pomoc w rozwiązaniu problemu"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
 msgstr "Wykrywanie zostało wyłączone z powodu liczby urządzeń w tej sieci."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Więcej informacji"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Zadzwoń"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Udostępnij plik"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr "Wyświetla listę dostępnych urządzeń"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr "Wyświetla listę wszystkich urządzeń"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr "Urządzenie docelowe"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr "Treść wiadomości"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Wyślij powiadomienie"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr "Nazwa aplikacji powiadomienia"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr "Treść powiadomienia"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr "Ikona powiadomienia"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr "Identyfikator powiadomienia"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Zdjęcie"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ping"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Zadzwoń"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Udostępnij odnośnik"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr "Wyświetla wersję wydania"
 
@@ -685,7 +694,7 @@ msgstr "Odbieranie ze schowka"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Nieznany kontakt"
@@ -919,7 +928,7 @@ msgid "%s・Home"
 msgstr "%s・Domowy"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Wyślij do „%s”"
@@ -955,7 +964,7 @@ msgstr "Wiadomość grupowa"
 msgid "You: %s"
 msgstr "Ja: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1042,7 +1051,9 @@ msgstr "GSConnect"
 #. TRANSLATORS: Chrome/Firefox WebExtension description
 #: webextension/gettext.js:29
 msgid "Share links with GSConnect, direct to the browser or by SMS."
-msgstr "Udostępnianie odnośników za pomocą GSConnect, bezpośrednio do przeglądarki lub przez wiadomość SMS."
+msgstr ""
+"Udostępnianie odnośników za pomocą GSConnect, bezpośrednio do przeglądarki "
+"lub przez wiadomość SMS."
 
 #. TRANSLATORS: WebExtension can't connect to GSConnect
 #: webextension/gettext.js:33
@@ -1053,4 +1064,3 @@ msgstr "Usługa jest niedostępna"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "Otwórz w przeglądarce"
-

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2018-11-24 21:11-0200\n"
 "Last-Translator: Ricardo Silva Veloso <ricvelozo@gmail.com>\n"
 "Language-Team: \n"
@@ -19,18 +19,18 @@ msgstr ""
 "X-Generator: Poedit 2.2\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Informação de criptografia"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Parear"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Esquecer"
 
@@ -41,8 +41,8 @@ msgstr "Conectar a…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -71,17 +71,17 @@ msgstr "Ajuda"
 msgid "Type a phone number or name"
 msgstr "Digite um número de telefone ou nome"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Escrever uma mensagem"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 #, fuzzy
 msgid "Send Message"
 msgstr "Nova mensagem"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Computador"
 
@@ -119,7 +119,7 @@ msgstr "Compartilhar"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Comandos"
 
@@ -296,11 +296,11 @@ msgid "Mute"
 msgstr "Silenciar"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Mensagens"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 #, fuzzy
 msgid "New Conversation"
 msgstr "Selecione uma conversa"
@@ -342,8 +342,9 @@ msgstr ""
 msgid "Refresh"
 msgstr "Recarregar"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Configurações de dispositivos"
 
@@ -356,7 +357,7 @@ msgstr ""
 msgid "Devices"
 msgstr "Para o dispositivo"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr ""
 
@@ -373,7 +374,7 @@ msgstr "Tablet"
 msgid "This device is invisible to unpaired devices"
 msgstr ""
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Descoberta desativada"
 
@@ -392,7 +393,7 @@ msgid "User Menu"
 msgstr "Menu do usuário"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr ""
 
@@ -402,22 +403,22 @@ msgid "About GSConnect"
 msgstr "GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Enviar SMS"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Dispositivos móveis"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr ""
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -425,7 +426,7 @@ msgstr[0] "%d conectado"
 msgstr[1] "%d conectados"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr ""
 
@@ -434,208 +435,208 @@ msgstr ""
 msgid "Send To Mobile Device"
 msgstr "Enviar para dispositivo móvel"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Abrir"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Ativada"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Desativada"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Desativado"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Definir atalho"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Definir"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Digite um novo atalho para mudar <b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgstr ""
 "Pressione Esc para cancelar ou Backspace para redefinir o atalho de teclado."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s já está em uso"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Uma implementação completa do KDE Connect para o GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "Ricardo Silva Veloso <ricvelozo@gmail.com>"
 
-#: src/preferences/service.js:430
+#: src/preferences/service.js:426
 msgid ""
 "Debug messages are being logged. Take any steps necessary to reproduce a "
 "problem then review the log."
 msgstr ""
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr ""
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Laptop"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Smartphone"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Tablet"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 #, fuzzy
 msgid "Television"
 msgstr "Telefonia"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 #, fuzzy
 msgid "Unpaired"
 msgstr "Esquecer"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 #, fuzzy
 msgid "Disconnected"
 msgstr "Dispositivo está desconectado"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 #, fuzzy
 msgid "Connected"
 msgstr "Conectar"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr ""
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Reportar"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Falha de autenticação"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Erro de rede"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Clique para ajuda na solução de problemas"
 
-#: src/service/daemon.js:599
+#: src/service/daemon.js:595
 msgid ""
 "Discovery has been disabled due to the number of devices on this network."
 msgstr ""
 "A descoberta foi desativada devido ao número de dispositivos nesta rede."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Clique para mais informação"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Ligar para número"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Compartilhar arquivo"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 #, fuzzy
 msgid "List available devices"
 msgstr "Indisponível"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 #, fuzzy
 msgid "List all devices"
 msgstr "Dispositivos móveis"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 #, fuzzy
 msgid "Target Device"
 msgstr "Para o dispositivo"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 #, fuzzy
 msgid "Message Body"
 msgstr "Nova mensagem"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Enviar notificação"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 #, fuzzy
 msgid "Notification App Name"
 msgstr "Notificações"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 #, fuzzy
 msgid "Notification Body"
 msgstr "Notificações"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 #, fuzzy
 msgid "Notification Icon"
 msgstr "Notificações"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 #, fuzzy
 msgid "Notification ID"
 msgstr "Notificações"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr ""
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ping"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 #, fuzzy
 msgid "Ring"
 msgstr "Localizar"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Compartilhar link"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 #, fuzzy
 msgid "Show release version"
 msgstr "Selecione uma conversa"
@@ -717,7 +718,7 @@ msgstr "Pegar da área de transferência"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Contato desconhecido"
@@ -955,7 +956,7 @@ msgid "%s・Home"
 msgstr "%s・Casa"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Enviar para %s"
@@ -990,7 +991,7 @@ msgstr "Nova mensagem"
 msgid "You: %s"
 msgstr ""
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"

--- a/po/ru.po
+++ b/po/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-10 11:34\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: Russian\n"
@@ -10,25 +10,27 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=((n%10==1 && n%100!=11) ? 0 : ((n%10 >= 2 && n%10 <=4 && (n%100 < 12 || n%100 > 14)) ? 1 : ((n%10 == 0 || (n%10 >= 5 && n%10 <=9)) || (n%100 >= 11 && n%100 <= 14)) ? 2 : 3));\n"
+"Plural-Forms: nplurals=4; plural=((n%10==1 && n%100!=11) ? 0 : ((n%10 >= 2 "
+"&& n%10 <=4 && (n%100 < 12 || n%100 > 14)) ? 1 : ((n%10 == 0 || (n%10 >= 5 "
+"&& n%10 <=9)) || (n%100 >= 11 && n%100 <= 14)) ? 2 : 3));\n"
 "X-Generator: crowdin.com\n"
 "X-Crowdin-Project: gsconnect\n"
 "X-Crowdin-Language: ru\n"
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Информация о шифровании"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Сопряжение"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Забыть"
 
@@ -39,8 +41,8 @@ msgstr "Подключиться к…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +70,16 @@ msgstr "Помощь"
 msgid "Type a phone number or name"
 msgstr "Наберите номер или имя"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Набрать сообщение"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Отправить сообщение"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Компьютер"
 
@@ -115,7 +117,7 @@ msgstr "Общий доступ и обмен"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Команды"
 
@@ -286,11 +288,11 @@ msgid "Mute"
 msgstr "Выключить"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Сообщение"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Новый диалог"
 
@@ -328,8 +330,9 @@ msgstr "_Переименовать"
 msgid "Refresh"
 msgstr "Обновить"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Настройки"
 
@@ -341,7 +344,7 @@ msgstr "Редактировать название устройства"
 msgid "Devices"
 msgstr "Устройства"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Поиск устройств…"
 
@@ -357,7 +360,7 @@ msgstr "Включить"
 msgid "This device is invisible to unpaired devices"
 msgstr "Это устройство является невидимым для неспаренных устройств"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Обнаружение выключено"
 
@@ -376,7 +379,7 @@ msgid "User Menu"
 msgstr "Меню пользователя"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Сгенерировать журнал"
 
@@ -385,22 +388,22 @@ msgid "About GSConnect"
 msgstr "О GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Отправить СМС"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Устройства"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr "Включить"
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -410,7 +413,7 @@ msgstr[2] "%d подключено"
 msgstr[3] "%d подключено"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr "Выключить"
 
@@ -419,190 +422,195 @@ msgstr "Выключить"
 msgid "Send To Mobile Device"
 msgstr "Отправить на устройство"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Открыть"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Вкл"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Выкл"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Отключено"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Установить комбинацию клавиш"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Выбор"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Введите новую комбинацию клавиш для <b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgstr "Нажмите Esc для отмены или Backspace чтобы сбросить комбинацию."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s уже используется"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Полная реализация KDE Connect для GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "'Losted' <losted@wants.dicksinhisan.us>"
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
-msgstr "Отладочные сообщения будут записаны. Произведите действия при которых произошла проблема, затем посмотрите журнал."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
+msgstr ""
+"Отладочные сообщения будут записаны. Произведите действия при которых "
+"произошла проблема, затем посмотрите журнал."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Посмотреть журнал"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Ноутбук"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Смартфон"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Планшет"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "Телевидение"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Не сопряжен"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Отключено"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Подключено"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "Ожидание службы…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Отзыв"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Ошибка аутентификации"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Ошибка сети"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Нажмите для решения проблем"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
 msgstr "Обнаружение было выключено из-за количества устройств в этой сети."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Нажмите для получения информации"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Вызвать номер"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Поделиться файлом"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr "Список доступных устройств"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr "Список всех устройств"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr "Целевое устройство"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr "Текст сообщения"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Отправить"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr "Имя приложения"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr "Текст уведомления"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr "Иконка уведомления"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr "ID уведомления"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Фото"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Пинг"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Найти"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Поделиться ссылкой"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr "Показать версию программы"
 
@@ -683,7 +691,7 @@ msgstr "Запросить Буфер обмена"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Неизвестный контакт"
@@ -917,7 +925,7 @@ msgid "%s・Home"
 msgstr "%s・Домашний"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Отправить на %s"
@@ -953,7 +961,7 @@ msgstr "Групповое сообщение"
 msgid "You: %s"
 msgstr "Вы: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1051,4 +1059,3 @@ msgstr "Сервис недоступен"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "Открыть в браузере"
-

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-09-29 16:23+0200\n"
 "Last-Translator: Jose Riha <jose1711@gmail.com>\n"
 "Language-Team: \n"
@@ -19,18 +19,18 @@ msgstr ""
 "X-Generator: Poedit 2.2.1\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Informácie o šifrovaní"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Spárovať"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Zrušiť párovanie"
 
@@ -41,8 +41,8 @@ msgstr "Pripojiť k…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -70,16 +70,16 @@ msgstr "Pomocník"
 msgid "Type a phone number or name"
 msgstr "Zadajte telefónne číslo alebo meno"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Zadajte správu"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Odoslať správu"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Stolný počítač"
 
@@ -117,7 +117,7 @@ msgstr "Zdieľanie"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Príkazy"
 
@@ -288,11 +288,11 @@ msgid "Mute"
 msgstr "Stíšiť"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Písanie správ"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Nová konverzácia"
 
@@ -330,8 +330,9 @@ msgstr "_Premenovať"
 msgid "Refresh"
 msgstr "Obnoviť"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Mobilné nastavenia"
 
@@ -343,7 +344,7 @@ msgstr "Upraviť meno zariadenia"
 msgid "Devices"
 msgstr "Zariadenia"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Hľadajú sa zariadenia…"
 
@@ -359,7 +360,7 @@ msgstr "Povoliť"
 msgid "This device is invisible to unpaired devices"
 msgstr "Toto zariadenie nie je viditeľné pre nespárované zariadenia"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Objavenie zakázané"
 
@@ -378,7 +379,7 @@ msgid "User Menu"
 msgstr "Užívateľská ponuka"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Vytvoriť záznam pre technickú podporu"
 
@@ -387,22 +388,22 @@ msgid "About GSConnect"
 msgstr "O programe GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Odoslať SMS"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Mobilné zariadenia"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr "Zapnúť"
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -411,7 +412,7 @@ msgstr[1] "%d pripojené"
 msgstr[2] "%d pripojených"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr "Vypnúť"
 
@@ -420,41 +421,41 @@ msgstr "Vypnúť"
 msgid "Send To Mobile Device"
 msgstr "Odoslať do mobilného zariadenia"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Otvoriť"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Zapnuté"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Vypnuté"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Zakázané"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Nastavenie skratky"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Nastaviť"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Zadajte novú skratku pre zmenu akcie <b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgstr ""
 "Stlačte klávesu Esc na zrušenie alebo klávesu Backspace na obnovenie "
@@ -462,21 +463,21 @@ msgstr ""
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "Klávesová skratka %s sa už používa"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Kompletná implementácia aplikácie KDE Connect pre prostredie GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "Dušan Kazik <prescott66@gmail.com>, Jose Riha <jose1711@gmail.com>"
 
-#: src/preferences/service.js:430
+#: src/preferences/service.js:426
 msgid ""
 "Debug messages are being logged. Take any steps necessary to reproduce a "
 "problem then review the log."
@@ -484,133 +485,133 @@ msgstr ""
 "Správy ladenia sú zaznamenávané. Pokúste sa opätovne vyvolať problém a "
 "pozrite sa na súbor so záznamom."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Prezrieť súbor so záznamom"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Notebook"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Smartphone"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Tablet"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "Televízia"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Spárovanie zrušené"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Odpojené"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Pripojené"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "Čaká sa na službu…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Ohlásiť"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Zlyhalo overenie totožnosti"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Sieťová chyba"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Kliknutím získate pomoc pri riešení problému"
 
-#: src/service/daemon.js:599
+#: src/service/daemon.js:595
 msgid ""
 "Discovery has been disabled due to the number of devices on this network."
 msgstr "Objavenie bolo zakázané kvôli počtu zariadení na tejto sieti."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Kliknutím získate viac informácií"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Vytočiť číslo"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Zdieľať súbor"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr "Zobraziť dostupné zariadenia"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr "Zobraziť všetky zariadenia"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr "Cieľové zariadenie"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr "Telo správy"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Odoslať oznámenie"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr "Meno aplikácie v oznámení"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr "Telo oznámenia"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr "Ikona oznámenia"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr "ID oznámenia"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Fotografia"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ping"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Prezvoniť"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Zdieľať odkaz"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr "Zobraziť verziu vydania"
 
@@ -691,7 +692,7 @@ msgstr "Prijať obsah schránky"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Neznámy kontakt"
@@ -926,7 +927,7 @@ msgid "%s・Home"
 msgstr "%s・Domov"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Odoslať na číslo %s"
@@ -961,7 +962,7 @@ msgstr "Skupinová správa"
 msgid "You: %s"
 msgstr "Vy: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"

--- a/po/sr.po
+++ b/po/sr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-09-25 15:46+0200\n"
 "Last-Translator: Слободан Терзић <slobodan.terzic@zoho.eu>\n"
 "Language-Team: \n"
@@ -15,18 +15,18 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Информације о шифровању"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Упари"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Распари"
 
@@ -37,8 +37,8 @@ msgstr "Повежи се са…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -66,16 +66,16 @@ msgstr "Помоћ"
 msgid "Type a phone number or name"
 msgstr "Унеите број телефона или име"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Унесите поруку"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Пошаљи поруку"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Радна површ"
 
@@ -113,7 +113,7 @@ msgstr "Дељење"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Наредбе"
 
@@ -284,11 +284,11 @@ msgid "Mute"
 msgstr "Утишај"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Поруке"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Нови разговор"
 
@@ -326,8 +326,9 @@ msgstr "_Преименуј"
 msgid "Refresh"
 msgstr "Освежи"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Подешавање"
 
@@ -339,7 +340,7 @@ msgstr "Уреди назив уређаја"
 msgid "Devices"
 msgstr "Уређаји"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Тражим уређаје…"
 
@@ -355,7 +356,7 @@ msgstr "Омогући"
 msgid "This device is invisible to unpaired devices"
 msgstr "Овај уређај је невидљив неупареним уређајима"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Откривање је онемогућено"
 
@@ -374,7 +375,7 @@ msgid "User Menu"
 msgstr "Кориснички мени"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Направи дневник за подршку"
 
@@ -384,22 +385,22 @@ msgid "About GSConnect"
 msgstr "О програму"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Пошаљи СМС"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Мобилни уређаји"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr ""
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, fuzzy, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -408,7 +409,7 @@ msgstr[1] "%d је повезан"
 msgstr[2] "%d је повезан"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr ""
 
@@ -417,62 +418,62 @@ msgstr ""
 msgid "Send To Mobile Device"
 msgstr "Пошаљи на мобилни уређај"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Отвори"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Укључен"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Искључен"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Онемогућен"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Постави пречицу"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Постави"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Унесите нову пречицу да замените <b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgstr ""
 "Притисните Есц да откажете или Повратник да ресетујете пречицу тастатуре."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s је спреман за употребу"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Потпуна имплементација КДЕ Конекта за Гном"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "Слободан Терзић (githzerai06@gmail.com)"
 
-#: src/preferences/service.js:430
+#: src/preferences/service.js:426
 msgid ""
 "Debug messages are being logged. Take any steps necessary to reproduce a "
 "problem then review the log."
@@ -480,141 +481,141 @@ msgstr ""
 "Поруке за исправљање грешака се бележе. Предузмите неопходне кораке да "
 "поново призведете проблем и прегеледајте дневник."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Преглед дневника"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Лаптоп"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Паметни телефон"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Таблет"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "Телевизија"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Распарен"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Неповезан"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Повезан"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "Чекам на сервис…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Пријави"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Грешка аутентификацје"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Грешка мреже"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Кликните за помоћ у отклањању"
 
-#: src/service/daemon.js:599
+#: src/service/daemon.js:595
 msgid ""
 "Discovery has been disabled due to the number of devices on this network."
 msgstr "Откривање је онемогућено услед броја уређаја у овој мрежи."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Кликните за више детаља"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Бирај број"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Дели фајл"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 #, fuzzy
 msgid "List available devices"
 msgstr "Није доступно"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 #, fuzzy
 msgid "List all devices"
 msgstr "Мобилни уређаји"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 #, fuzzy
 msgid "Target Device"
 msgstr "На уређај"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 #, fuzzy
 msgid "Message Body"
 msgstr "Нова порука"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Пошаљи обавештење"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 #, fuzzy
 msgid "Notification App Name"
 msgstr "Обавештења"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 #, fuzzy
 msgid "Notification Body"
 msgstr "Обавештења"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 #, fuzzy
 msgid "Notification Icon"
 msgstr "Обавештења"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 #, fuzzy
 msgid "Notification ID"
 msgstr "Обавештења"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Фотографије"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Пинг"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Позвони"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Подели везу"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 #, fuzzy
 msgid "Show release version"
 msgstr "Додајте особе да започнете разговор"
@@ -696,7 +697,7 @@ msgstr "Довлачење из оставе"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Непознат контакт"
@@ -933,7 +934,7 @@ msgid "%s・Home"
 msgstr "%s・Кућни"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Пошаљи на %s"
@@ -969,7 +970,7 @@ msgstr "Нова порука"
 msgid "You: %s"
 msgstr ""
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-09-25 15:46+0200\n"
 "Last-Translator: Slobodan Terzić <slobodan.terzic@zoho.eu>\n"
 "Language-Team: \n"
@@ -15,18 +15,18 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Informacije o šifrovanju"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Upari"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Raspari"
 
@@ -37,8 +37,8 @@ msgstr "Poveži se sa…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -66,16 +66,16 @@ msgstr "Pomoć"
 msgid "Type a phone number or name"
 msgstr "Uneite broj telefona ili ime"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Unesite poruku"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Pošalji poruku"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Radna površ"
 
@@ -113,7 +113,7 @@ msgstr "Deljenje"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Naredbe"
 
@@ -284,11 +284,11 @@ msgid "Mute"
 msgstr "Utišaj"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Poruke"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Novi razgovor"
 
@@ -326,8 +326,9 @@ msgstr "_Preimenuj"
 msgid "Refresh"
 msgstr "Osveži"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Podešavanje"
 
@@ -339,7 +340,7 @@ msgstr "Uredi naziv uređaja"
 msgid "Devices"
 msgstr "Uređaji"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Tražim uređaje…"
 
@@ -355,7 +356,7 @@ msgstr "Omogući"
 msgid "This device is invisible to unpaired devices"
 msgstr "Ovaj uređaj je nevidljiv neuparenim uređajima"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Otkrivanje je onemogućeno"
 
@@ -374,7 +375,7 @@ msgid "User Menu"
 msgstr "Korisnički meni"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Napravi dnevnik za podršku"
 
@@ -384,22 +385,22 @@ msgid "About GSConnect"
 msgstr "O programu"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Pošalji SMS"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Mobilni uređaji"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr ""
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, fuzzy, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -408,7 +409,7 @@ msgstr[1] "%d je povezan"
 msgstr[2] "%d je povezan"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr ""
 
@@ -417,62 +418,62 @@ msgstr ""
 msgid "Send To Mobile Device"
 msgstr "Pošalji na mobilni uređaj"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Otvori"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Uključen"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Isključen"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Onemogućen"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Postavi prečicu"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Postavi"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Unesite novu prečicu da zamenite <b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgstr ""
 "Pritisnite Esc da otkažete ili Povratnik da resetujete prečicu tastature."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s je spreman za upotrebu"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Potpuna implementacija KDE Konekta za Gnom"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "Slobodan Terzić (githzerai06@gmail.com)"
 
-#: src/preferences/service.js:430
+#: src/preferences/service.js:426
 msgid ""
 "Debug messages are being logged. Take any steps necessary to reproduce a "
 "problem then review the log."
@@ -480,141 +481,141 @@ msgstr ""
 "Poruke za ispravljanje grešaka se beleže. Preduzmite neophodne korake da "
 "ponovo prizvedete problem i pregeledajte dnevnik."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Pregled dnevnika"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Laptop"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Pametni telefon"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Tablet"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "Televizija"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Rasparen"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Nepovezan"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Povezan"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "Čekam na servis…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Prijavi"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Greška autentifikacje"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Greška mreže"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Kliknite za pomoć u otklanjanju"
 
-#: src/service/daemon.js:599
+#: src/service/daemon.js:595
 msgid ""
 "Discovery has been disabled due to the number of devices on this network."
 msgstr "Otkrivanje je onemogućeno usled broja uređaja u ovoj mreži."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Kliknite za više detalja"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Biraj broj"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Deli fajl"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 #, fuzzy
 msgid "List available devices"
 msgstr "Nije dostupno"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 #, fuzzy
 msgid "List all devices"
 msgstr "Mobilni uređaji"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 #, fuzzy
 msgid "Target Device"
 msgstr "Na uređaj"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 #, fuzzy
 msgid "Message Body"
 msgstr "Nova poruka"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Pošalji obaveštenje"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 #, fuzzy
 msgid "Notification App Name"
 msgstr "Obaveštenja"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 #, fuzzy
 msgid "Notification Body"
 msgstr "Obaveštenja"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 #, fuzzy
 msgid "Notification Icon"
 msgstr "Obaveštenja"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 #, fuzzy
 msgid "Notification ID"
 msgstr "Obaveštenja"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Fotografije"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ping"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Pozvoni"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Podeli vezu"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 #, fuzzy
 msgid "Show release version"
 msgstr "Dodajte osobe da započnete razgovor"
@@ -696,7 +697,7 @@ msgstr "Dovlačenje iz ostave"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Nepoznat kontakt"
@@ -933,7 +934,7 @@ msgid "%s・Home"
 msgstr "%s・Kućni"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Pošalji na %s"
@@ -969,7 +970,7 @@ msgstr "Nova poruka"
 msgid "You: %s"
 msgstr ""
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"

--- a/po/tr.po
+++ b/po/tr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-11 03:35\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: Turkish\n"
@@ -17,18 +17,18 @@ msgstr ""
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Şifreleme Bilgisi"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Eşleştir"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Eşleştirmeyi Bitir"
 
@@ -39,8 +39,8 @@ msgstr "Bağlan…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +68,16 @@ msgstr "Yardım"
 msgid "Type a phone number or name"
 msgstr "Telefon numarası veya isim yaz"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Bir Mesaj Yaz"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Mesaj Gönder"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Masaüstü"
 
@@ -115,7 +115,7 @@ msgstr "Paylaşım"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Komutlar"
 
@@ -286,11 +286,11 @@ msgid "Mute"
 msgstr "Sessiz"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Mesajlaşma"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Yeni Sohbet"
 
@@ -328,8 +328,9 @@ msgstr "_Adlandır"
 msgid "Refresh"
 msgstr "Yenile"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Mobil Ayarları"
 
@@ -341,7 +342,7 @@ msgstr "Cihaz Adını Düzenle"
 msgid "Devices"
 msgstr "Cihazlar"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Cihazlar aranıyor…"
 
@@ -357,7 +358,7 @@ msgstr "Etkin"
 msgid "This device is invisible to unpaired devices"
 msgstr "Bu cihaz eşleştirme yapılmayan cihazlara görünmez"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Keşif Devre Dışı"
 
@@ -376,7 +377,7 @@ msgid "User Menu"
 msgstr "Kullanıcı Menüsü"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Destek Günlüğü Oluştur"
 
@@ -385,22 +386,22 @@ msgid "About GSConnect"
 msgstr "GSConnect Hakkında"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "SMS Gönder"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Mobil Cihazlar"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr "Aç"
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -408,7 +409,7 @@ msgstr[0] "%d Bağlı"
 msgstr[1] "%d Bağlı"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr "Kapat"
 
@@ -417,192 +418,199 @@ msgstr "Kapat"
 msgid "Send To Mobile Device"
 msgstr "Mobil Cihaza Gönder"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Aç"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Açık"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Kapalı"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Devre dışı"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Kısayol Ayarla"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Ayarla"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Değiştirmek için yeni bir kısayol gir <b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
-msgstr "Klavye kısayolunu sıfırlamak için iptal, geri almak için ESC tuşuna bas."
+msgstr ""
+"Klavye kısayolunu sıfırlamak için iptal, geri almak için ESC tuşuna bas."
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s zaten kullanılıyor"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "GNOME için eksiksiz bir KDE Connect uygulaması"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
-msgstr "Serdar Sağlam <teknomobil@yandex.com>\n"
+msgstr ""
+"Serdar Sağlam <teknomobil@yandex.com>\n"
 "Orhan Engin Okay <orhanenginokay@hotmail.com>\n"
 "A. Burak Tektaş <abtektas@gmail.com>"
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
-msgstr "Hata ayıklama mesajları kaydediliyor. Sorunu yeniden oluşturmak için gerekli adımları izleyin ve günlüğü inceleyin."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
+msgstr ""
+"Hata ayıklama mesajları kaydediliyor. Sorunu yeniden oluşturmak için gerekli "
+"adımları izleyin ve günlüğü inceleyin."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Günlüğü Gözden Geçir"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Dizüstü"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Telefon"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Tablet"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "Televizyon"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Eşleşmemiş"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Bağlantı kesildi"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Bağlı"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "Hizmet bekleniyor…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Rapor"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Kimlik Doğrulama Hatası"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Ağ Hatası"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Sorun giderme konusunda yardım için tıkla"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
 msgstr "Bu ağdaki cihazların sayısı nedeniyle keşif devre dışı bırakıldı."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Daha fazla bilgi için tıkla"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Numarayı Çevir"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Dosya Paylaşımı"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr "Kullanılabilir cihazları listele"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr "Tüm cihazları listele"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr "Hedef Cihaz"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr "Mesaj Metni"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Bildirim Gönder"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr "Bildirim Uygulama Adı"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr "Bildirim Metni"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr "Bildirim Simgesi"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr "Bildirim Kimliği"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Fotoğraf"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Yokla"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Çaldır"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Bağlantıyı Paylaş"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr "Sürüm versiyonunu göster"
 
@@ -683,7 +691,7 @@ msgstr "Panodan Al"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Bilinmeyen Kişi"
@@ -917,7 +925,7 @@ msgid "%s・Home"
 msgstr "%s・Ev"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Gönder %s"
@@ -951,7 +959,7 @@ msgstr "Grup Mesajı"
 msgid "You: %s"
 msgstr "Sen: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1045,4 +1053,3 @@ msgstr "Servis Mevcut Değil"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "Tarayıcıda Aç"
-

--- a/po/uk.po
+++ b/po/uk.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-10 11:13\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: Ukrainian\n"
@@ -10,25 +10,27 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=((n%10==1 && n%100!=11) ? 0 : ((n%10 >= 2 && n%10 <=4 && (n%100 < 12 || n%100 > 14)) ? 1 : ((n%10 == 0 || (n%10 >= 5 && n%10 <=9)) || (n%100 >= 11 && n%100 <= 14)) ? 2 : 3));\n"
+"Plural-Forms: nplurals=4; plural=((n%10==1 && n%100!=11) ? 0 : ((n%10 >= 2 "
+"&& n%10 <=4 && (n%100 < 12 || n%100 > 14)) ? 1 : ((n%10 == 0 || (n%10 >= 5 "
+"&& n%10 <=9)) || (n%100 >= 11 && n%100 <= 14)) ? 2 : 3));\n"
 "X-Generator: crowdin.com\n"
 "X-Crowdin-Project: gsconnect\n"
 "X-Crowdin-Language: uk\n"
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "Дані щодо шифрування"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "Пов'язати"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "Відв'язати"
 
@@ -39,8 +41,8 @@ msgstr "Під'єднатися до…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +70,16 @@ msgstr "Допомога"
 msgid "Type a phone number or name"
 msgstr "Введіть номер телефону або ім'я"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "Введіть повідомлення"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "Відправити повідомлення"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "Настільний комп'ютер"
 
@@ -115,7 +117,7 @@ msgstr "Надання доступу"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "Команди"
 
@@ -286,11 +288,11 @@ msgid "Mute"
 msgstr "Вимкнути"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "Повідомлення"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "Нова бесіда"
 
@@ -328,8 +330,9 @@ msgstr ""
 msgid "Refresh"
 msgstr "Оновити"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "Параметри мобільних пристроїв"
 
@@ -341,7 +344,7 @@ msgstr "Редагувати ім'я пристрою"
 msgid "Devices"
 msgstr "Пристрої"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "Пошук пристроїв…"
 
@@ -357,7 +360,7 @@ msgstr "Увімкнути"
 msgid "This device is invisible to unpaired devices"
 msgstr "Цей пристрій є невидимим для непов'язаних пристроїв"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "Видимість вимкнено"
 
@@ -376,7 +379,7 @@ msgid "User Menu"
 msgstr "Меню користувача"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "Згенерувати журнал для підтримки"
 
@@ -385,22 +388,22 @@ msgid "About GSConnect"
 msgstr "Про GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "Відправити SMS"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "Мобільні пристрої"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr ""
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
@@ -410,7 +413,7 @@ msgstr[2] "%d під'єднано"
 msgstr[3] ""
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr ""
 
@@ -419,190 +422,196 @@ msgstr ""
 msgid "Send To Mobile Device"
 msgstr "Відправити до мобільного пристрою"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "Відкрити"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "Вимкнено"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "Увімкнено"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "Вимкнено"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "Встановити скорочення"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "Встановити"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "Введіть нове скорочення, щоб замінити <b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
-msgstr "Натисніть Esc щоб скасувати або Backspace щоб скинути комбінацію клавіш"
+msgstr ""
+"Натисніть Esc щоб скасувати або Backspace щоб скинути комбінацію клавіш"
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s вже використовується"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "Повна реалізація KDE Connect для GNOME"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "kotyhoroshko"
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
-msgstr "Повідомлення налагодження записуються. Виконайте всі необхідні дії для відтворення проблеми, а потім перегляньте журнал."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
+msgstr ""
+"Повідомлення налагодження записуються. Виконайте всі необхідні дії для "
+"відтворення проблеми, а потім перегляньте журнал."
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "Переглянути журнал"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "Ноутбук"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "Смартфон"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "Планшет"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr ""
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "Не пов'язаний"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "Від'єднаний"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "Під'єднаний"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr ""
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "Повідомити"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "Помилка аутентифікації"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "Помилка мережі"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "Натисніть, щоб допомогти усунути проблему"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
 msgstr "Видимість було вимкнено через велику кількість пристроїв у цій мережі."
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "Натисніть для отримання додаткової інформації"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "Набрати номер"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "Поділитися файлом"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr ""
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr ""
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr ""
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr ""
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "Відправити сповіщення"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr ""
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr ""
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr ""
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr ""
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "Фото"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Пінг"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "Дзвеніти"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "Поділитися посиланням"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr ""
 
@@ -683,7 +692,7 @@ msgstr "Отримувати з буферу обміну"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "Невідомий контакт"
@@ -917,7 +926,7 @@ msgid "%s・Home"
 msgstr "%s・Домашній"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "Відправити до %s"
@@ -953,7 +962,7 @@ msgstr ""
 msgid "You: %s"
 msgstr "Ви: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1040,7 +1049,9 @@ msgstr "GSConnect"
 #. TRANSLATORS: Chrome/Firefox WebExtension description
 #: webextension/gettext.js:29
 msgid "Share links with GSConnect, direct to the browser or by SMS."
-msgstr "Поширюйте посилання за допомогою GSConnect, напряму до браузера або через SMS."
+msgstr ""
+"Поширюйте посилання за допомогою GSConnect, напряму до браузера або через "
+"SMS."
 
 #. TRANSLATORS: WebExtension can't connect to GSConnect
 #: webextension/gettext.js:33
@@ -1051,4 +1062,3 @@ msgstr "Сервіс недоступний"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "Відкрити у браузері"
-

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-10 11:13\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: Chinese Simplified\n"
@@ -17,18 +17,18 @@ msgstr ""
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "加密信息"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "配对"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "取消配对"
 
@@ -39,8 +39,8 @@ msgstr "连接到..."
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +68,16 @@ msgstr "帮助"
 msgid "Type a phone number or name"
 msgstr "输入电话号码或姓名"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "键入消息"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "发送消息"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "桌面"
 
@@ -115,7 +115,7 @@ msgstr "共享"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "命令"
 
@@ -286,11 +286,11 @@ msgid "Mute"
 msgstr "静音"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "消息"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "新建对话"
 
@@ -328,8 +328,9 @@ msgstr "修改名称"
 msgid "Refresh"
 msgstr "刷新"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "移动设置"
 
@@ -341,7 +342,7 @@ msgstr "编辑设备名称"
 msgid "Devices"
 msgstr "设备"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "正在搜索设备…"
 
@@ -357,7 +358,7 @@ msgstr "启用"
 msgid "This device is invisible to unpaired devices"
 msgstr "此设备对未配对的设备不可见"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "发现已禁用"
 
@@ -376,7 +377,7 @@ msgid "User Menu"
 msgstr "用户菜单"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "生成支持日志"
 
@@ -385,29 +386,29 @@ msgid "About GSConnect"
 msgstr "关于 GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "发送短信"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "移动设备"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr "开启"
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
 msgstr[0] "%d 连接"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr "关闭"
 
@@ -416,190 +417,193 @@ msgstr "关闭"
 msgid "Send To Mobile Device"
 msgstr "发送到移动设备"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "打开"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "开"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "关"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "禁用"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "设置快捷方式"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "设置"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "输入新的快捷方式 <b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgstr "按 Esc 键取消，或按 Backsace 键重置键盘快捷方式。"
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "%s 已在使用中"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "KDE Connect 在 GNOME 的完整实现"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "翻译贡献"
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
 msgstr "正在记录调试日志。请采取任何必要的步骤来重现问题，然后即可查看日志。"
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "查看日志"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "笔记本电脑"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "智能手机"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "平板电脑"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "电视"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "未配对"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "已断开"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "已连接"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "等待服务响应..."
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "报告"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "身份验证失败"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "网络错误"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "单击以获取疑难解答帮助"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
 msgstr "由于此网络上的设备数量，已禁用发现。"
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "单击以获取详细信息"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "拨打号码"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "共享文件"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr "可用设备列表"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr "所有可用设备"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr "目标设备"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr "消息正文"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "发送通知"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr "通知的应用名称"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr "通知的信息正文"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr "通知的图标"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr "通知的ID"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "照片"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ping"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "响铃"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "共享链接"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr "显示版本信息"
 
@@ -680,7 +684,7 @@ msgstr "获取剪贴板"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "未知联系人"
@@ -914,7 +918,7 @@ msgid "%s・Home"
 msgstr "%s・住宅"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "发送到 %s"
@@ -947,7 +951,7 @@ msgstr "群组消息"
 msgid "You: %s"
 msgstr "你: %s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1039,4 +1043,3 @@ msgstr "服务不可用"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "在浏览器中打开"
-

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gsconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-10 07:07-0400\n"
+"POT-Creation-Date: 2019-11-02 21:17-0400\n"
 "PO-Revision-Date: 2019-10-10 11:13\n"
 "Last-Translator: Andy Holmes (andyholmes)\n"
 "Language-Team: Chinese Traditional\n"
@@ -17,18 +17,18 @@ msgstr ""
 "X-Crowdin-File: /master/po/org.gnome.Shell.Extensions.GSConnect.pot\n"
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/gtk/menus.ui:7 src/preferences/device.js:293
+#: data/gtk/menus.ui:7 src/preferences/device.js:292
 msgid "Encryption Info"
 msgstr "加密資訊"
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/gtk/menus.ui:12 data/ui/device-preferences.ui:2497
-#: src/service/daemon.js:804
+#: src/service/daemon.js:800
 msgid "Pair"
 msgstr "配對"
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/gtk/menus.ui:18 src/service/daemon.js:813
+#: data/gtk/menus.ui:18 src/service/daemon.js:809
 msgid "Unpair"
 msgstr "取消配對"
 
@@ -39,8 +39,8 @@ msgstr "連線到…"
 
 #. Action Buttons
 #: data/ui/connect.ui:20 data/ui/notification-reply-dialog.ui:13
-#: data/ui/telephony.ui:14 src/preferences/device.js:657
-#: src/preferences/keybindings.js:86 src/preferences/service.js:432
+#: data/ui/telephony.ui:14 src/preferences/device.js:653
+#: src/preferences/keybindings.js:44 src/preferences/service.js:428
 #: src/service/plugins/share.js:161 src/service/plugins/share.js:309
 #: src/service/plugins/share.js:452 src/service/ui/service.js:37
 #: src/shell/donotdisturb.js:301
@@ -68,16 +68,16 @@ msgstr "幫助"
 msgid "Type a phone number or name"
 msgstr "輸入電話號碼或姓名"
 
-#: data/ui/conversation.ui:76 data/ui/conversation.ui:85
+#: data/ui/conversation.ui:77 data/ui/conversation.ui:86
 #: src/shell/notification.js:52
 msgid "Type a message"
 msgstr "輸入訊息"
 
-#: data/ui/conversation.ui:84 src/service/plugins/sms.js:50
+#: data/ui/conversation.ui:85 src/service/plugins/sms.js:50
 msgid "Send Message"
 msgstr "傳送訊息"
 
-#: data/ui/device-preferences.ui:40 src/preferences/service.js:510
+#: data/ui/device-preferences.ui:40 src/preferences/service.js:506
 msgid "Desktop"
 msgstr "桌面"
 
@@ -115,7 +115,7 @@ msgstr "分享"
 
 #: data/ui/device-preferences.ui:532 data/ui/device-preferences.ui:826
 #: data/ui/device-preferences.ui:2256 src/service/plugins/runcommand.js:18
-#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:199
+#: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:193
 msgid "Commands"
 msgstr "指令"
 
@@ -286,11 +286,11 @@ msgid "Mute"
 msgstr "靜音"
 
 #: data/ui/messaging-window.ui:14 src/service/plugins/sms.js:26
-#: src/service/ui/messaging.js:976
+#: src/service/ui/messaging.js:967
 msgid "Messaging"
 msgstr "發送簡訊"
 
-#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1193
+#: data/ui/messaging-window.ui:23 src/service/ui/messaging.js:1184
 msgid "New Conversation"
 msgstr "新的對話"
 
@@ -328,8 +328,9 @@ msgstr "重新命名（_R）"
 msgid "Refresh"
 msgstr "重新整理"
 
+#. Service Menu -> "Mobile Settings"
 #: data/ui/preferences-window.ui:111 data/ui/preferences-window.ui:128
-#: src/extension.js:151
+#: src/extension.js:148
 msgid "Mobile Settings"
 msgstr "手機設置"
 
@@ -341,7 +342,7 @@ msgstr "修改裝置名稱"
 msgid "Devices"
 msgstr "裝置"
 
-#: data/ui/preferences-window.ui:307 src/preferences/service.js:673
+#: data/ui/preferences-window.ui:307 src/preferences/service.js:669
 msgid "Searching for devices…"
 msgstr "正在搜尋裝置…"
 
@@ -357,7 +358,7 @@ msgstr "啟用"
 msgid "This device is invisible to unpaired devices"
 msgstr "未配對裝置看不到此裝置"
 
-#: data/ui/preferences-window.ui:656 src/service/daemon.js:598
+#: data/ui/preferences-window.ui:656 src/service/daemon.js:594
 msgid "Discovery Disabled"
 msgstr "禁止被探索"
 
@@ -376,7 +377,7 @@ msgid "User Menu"
 msgstr "使用者選單"
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:732 src/preferences/service.js:429
+#: data/ui/preferences-window.ui:732 src/preferences/service.js:425
 msgid "Generate Support Log"
 msgstr "產生支援 Log"
 
@@ -385,29 +386,29 @@ msgid "About GSConnect"
 msgstr "關於 GSConnect"
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/telephony.ui:9 src/service/daemon.js:699 src/service/daemon.js:825
+#: data/ui/telephony.ui:9 src/service/daemon.js:695 src/service/daemon.js:821
 #: src/service/plugins/sms.js:58 webextension/gettext.js:39
 msgid "Send SMS"
 msgstr "發送簡訊"
 
 #. Service Menu
-#: src/extension.js:118 src/extension.js:249
+#: src/extension.js:116 src/extension.js:250
 msgid "Mobile Devices"
 msgstr "行動裝置"
 
 #. TRANSLATORS: A menu option to activate the extension
-#: src/extension.js:145 src/extension.js:383
+#: src/extension.js:143 src/extension.js:384
 msgid "Turn On"
 msgstr "開啟"
 
-#: src/extension.js:244
+#: src/extension.js:245
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
 msgstr[0] "%d 已連線"
 
 #. TRANSLATORS: A menu option to deactivate the extension
-#: src/extension.js:380
+#: src/extension.js:381
 msgid "Turn Off"
 msgstr "關閉"
 
@@ -416,190 +417,193 @@ msgstr "關閉"
 msgid "Send To Mobile Device"
 msgstr "傳送到手機"
 
-#: src/preferences/device.js:658
+#: src/preferences/device.js:654
 msgid "Open"
 msgstr "打開"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "On"
 msgstr "開啟"
 
-#: src/preferences/device.js:713 src/preferences/device.js:726
+#: src/preferences/device.js:709 src/preferences/device.js:722
 msgid "Off"
 msgstr "關閉"
 
-#: src/preferences/device.js:831 src/preferences/device.js:859
+#: src/preferences/device.js:827 src/preferences/device.js:855
 msgid "Disabled"
 msgstr "停用"
 
 #. TRANSLATORS: Title of keyboard shortcut dialog
-#: src/preferences/keybindings.js:75
+#: src/preferences/keybindings.js:33
 msgid "Set Shortcut"
 msgstr "設置快捷鍵"
 
 #. TRANSLATORS: Button to confirm the new shortcut
-#: src/preferences/keybindings.js:89
+#: src/preferences/keybindings.js:47
 msgid "Set"
 msgstr "設定"
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:96
+#: src/preferences/keybindings.js:54
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
 msgstr "輸入新的快捷鍵取代 <b>%s</b>"
 
 #. TRANSLATORS: Keys for cancelling (␛) or resetting (␈) a shortcut
-#: src/preferences/keybindings.js:125
+#: src/preferences/keybindings.js:83
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgstr "按下 Esc 取消快捷鍵，或按下倒退鍵（Backspace）重設快捷鍵。"
 
 #. TRANSLATORS: When a keyboard shortcut is unavailable
 #. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:224
+#: src/preferences/keybindings.js:182
 #, javascript-format
 msgid "%s is already being used"
 msgstr "「%s」已經被使用"
 
-#: src/preferences/service.js:388
+#: src/preferences/service.js:384
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr "一個為 GNOME 完整實做的 KDE Connect"
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:397
+#: src/preferences/service.js:393
 msgid "translator-credits"
 msgstr "翻譯組員"
 
-#: src/preferences/service.js:430
-msgid "Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log."
+#: src/preferences/service.js:426
+msgid ""
+"Debug messages are being logged. Take any steps necessary to reproduce a "
+"problem then review the log."
 msgstr "除錯訊息已被紀錄。請執行任何可能造成問題的動作，然後查看日誌。"
 
-#: src/preferences/service.js:433
+#: src/preferences/service.js:429
 msgid "Review Log"
 msgstr "查看日誌"
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:498
 msgid "Laptop"
 msgstr "筆電"
 
-#: src/preferences/service.js:504
+#: src/preferences/service.js:500
 msgid "Smartphone"
 msgstr "智慧型手機"
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:502
 msgid "Tablet"
 msgstr "平板"
 
-#: src/preferences/service.js:508
+#: src/preferences/service.js:504
 msgid "Television"
 msgstr "電視"
 
-#: src/preferences/service.js:529
+#: src/preferences/service.js:525
 msgid "Unpaired"
 msgstr "未配對"
 
-#: src/preferences/service.js:533
+#: src/preferences/service.js:529
 msgid "Disconnected"
 msgstr "已中斷連線"
 
-#: src/preferences/service.js:537
+#: src/preferences/service.js:533
 msgid "Connected"
 msgstr "已連接"
 
-#: src/preferences/service.js:675
+#: src/preferences/service.js:671
 msgid "Waiting for service…"
 msgstr "等待伺服器…"
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:333
 msgid "Report"
 msgstr "回報"
 
-#: src/service/daemon.js:580
+#: src/service/daemon.js:576
 msgid "Authentication Failure"
 msgstr "認證失敗"
 
-#: src/service/daemon.js:589
+#: src/service/daemon.js:585
 msgid "Network Error"
 msgstr "網路錯誤"
 
-#: src/service/daemon.js:590
+#: src/service/daemon.js:586
 msgid "Click for help troubleshooting"
 msgstr "點擊以幫助除錯"
 
-#: src/service/daemon.js:599
-msgid "Discovery has been disabled due to the number of devices on this network."
+#: src/service/daemon.js:595
+msgid ""
+"Discovery has been disabled due to the number of devices on this network."
 msgstr "因為此網域內的裝置數量，探索已停用"
 
-#: src/service/daemon.js:608
+#: src/service/daemon.js:604
 msgid "Click for more information"
 msgstr "按一下以瞭解詳情"
 
-#: src/service/daemon.js:705
+#: src/service/daemon.js:701
 msgid "Dial Number"
 msgstr "撥打電話"
 
-#: src/service/daemon.js:711 src/service/daemon.js:921
+#: src/service/daemon.js:707 src/service/daemon.js:917
 #: src/service/plugins/share.js:27
 msgid "Share File"
 msgstr "分享檔案"
 
-#: src/service/daemon.js:774
+#: src/service/daemon.js:770
 msgid "List available devices"
 msgstr "列出可用裝置"
 
-#: src/service/daemon.js:783
+#: src/service/daemon.js:779
 msgid "List all devices"
 msgstr "列出所有裝置"
 
-#: src/service/daemon.js:792
+#: src/service/daemon.js:788
 msgid "Target Device"
 msgstr "目標裝置"
 
-#: src/service/daemon.js:834
+#: src/service/daemon.js:830
 msgid "Message Body"
 msgstr "訊息內文"
 
-#: src/service/daemon.js:846 src/service/plugins/notification.js:51
+#: src/service/daemon.js:842 src/service/plugins/notification.js:51
 msgid "Send Notification"
 msgstr "發送通知"
 
-#: src/service/daemon.js:855
+#: src/service/daemon.js:851
 msgid "Notification App Name"
 msgstr "程式名稱通知"
 
-#: src/service/daemon.js:864
+#: src/service/daemon.js:860
 msgid "Notification Body"
 msgstr "通知欄本身"
 
-#: src/service/daemon.js:873
+#: src/service/daemon.js:869
 msgid "Notification Icon"
 msgstr "通知圖示"
 
-#: src/service/daemon.js:882
+#: src/service/daemon.js:878
 msgid "Notification ID"
 msgstr "ID 通知"
 
-#: src/service/daemon.js:891 src/service/plugins/photo.js:11
+#: src/service/daemon.js:887 src/service/plugins/photo.js:11
 #: src/service/plugins/photo.js:17
 msgid "Photo"
 msgstr "拍攝"
 
-#: src/service/daemon.js:900 src/service/plugins/ping.js:11
+#: src/service/daemon.js:896 src/service/plugins/ping.js:11
 #: src/service/plugins/ping.js:17 src/service/plugins/ping.js:44
 msgid "Ping"
 msgstr "Ping"
 
-#: src/service/daemon.js:909 src/service/plugins/battery.js:155
+#: src/service/daemon.js:905 src/service/plugins/battery.js:155
 #: src/service/plugins/findmyphone.js:19
 msgid "Ring"
 msgstr "響音"
 
-#: src/service/daemon.js:930 src/service/plugins/share.js:43
-#: src/service/ui/messaging.js:1176 src/service/ui/messaging.js:1184
+#: src/service/daemon.js:926 src/service/plugins/share.js:43
+#: src/service/ui/messaging.js:1167 src/service/ui/messaging.js:1175
 msgid "Share Link"
 msgstr "共享鏈結"
 
-#: src/service/daemon.js:942
+#: src/service/daemon.js:938
 msgid "Show release version"
 msgstr "顯示版本"
 
@@ -680,7 +684,7 @@ msgstr "接收剪貼簿"
 #. Contact Name
 #: src/service/plugins/contacts.js:230 src/service/plugins/contacts.js:338
 #: src/service/plugins/telephony.js:170 src/service/plugins/telephony.js:221
-#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:571
+#: src/service/plugins/telephony.js:267 src/service/ui/contacts.js:569
 #: src/service/ui/messaging.js:247
 msgid "Unknown Contact"
 msgstr "未知的聯絡人"
@@ -914,7 +918,7 @@ msgid "%s・Home"
 msgstr "%s・家裡"
 
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
-#: src/service/ui/contacts.js:433 src/service/ui/contacts.js:447
+#: src/service/ui/contacts.js:431 src/service/ui/contacts.js:445
 #, javascript-format
 msgid "Send to %s"
 msgstr "傳送到「%s」"
@@ -947,7 +951,7 @@ msgstr "群組簡訊"
 msgid "You: %s"
 msgstr "你：%s"
 
-#: src/service/ui/messaging.js:869
+#: src/service/ui/messaging.js:861
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1039,4 +1043,3 @@ msgstr "服務無法使用"
 #: webextension/gettext.js:37
 msgid "Open in Browser"
 msgstr "以瀏覽器開啟"
-


### PR DESCRIPTION
<strike>As was pointed out, `'MPRIS'` shouldn't be a translatable string, so I removed the `_()` wrapping.</strike>

I've rethought that, I think I was steered wrong. Ultimately it doesn't _matter_, since NONE of the translation files have `'MPRIS'` translated into anything else. But I've removed the commit that excluded it from the translation master.

But while I was in there, I regenerated the POT and updated the PO files anyway.

