### PR TITLE
Fix sending battery state

### DIFF
--- a/src/service/plugins/battery.js
+++ b/src/service/plugins/battery.js
@@ -259,7 +259,7 @@ var Plugin = GObject.registerClass({
             return;
         }
 
-        let upower = this.service.get('upower');
+        let upower = this.service.components.get('upower');
 
         if (upower) {
             this.device.sendPacket({


### PR DESCRIPTION
Battery state could not be sent, because of a `TypeError: this.service.get is not a function` in `src/service/plugins/battery.js:262`.

After changing:
```diff
-        let upower = this.service.get('upower');
+        let upower = this.service.components.get('upower');
```
like in https://github.com/andyholmes/gnome-shell-extension-gsconnect/blob/133282b1d5d83301f8bdd8bc53eb7210e13a8c83/src/service/plugins/battery.js#L281
This error does not occur, and battery state is successfully sent.