### PR TITLE
Add .editorconfig file(s)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# Topmost editorconfig for project, don't ascend
+# to parent directories when scanning configs
+root = true
+
+# All files: UTF-8 with Unix-style newlines,
+# and a newline at the end of the file
+[*]
+insert_final_newline = true
+end_of_line = lf
+charset = utf-8
+
+# JavaScript, Python, CSS: 4-space indents
+[*.{js,py,css}]
+indent_style = space
+indent_size = 4
+
+# XML, Meson, Glade: 2-space indents
+[*.{xml,build,ui}]
+indent_style = space
+indent_size = 2
+
+# Most JSON: 2-space indents
+[*.json]
+indent_style = space
+indent_size = 2
+
+# WebExtension templates: 4-space indents
+[data/org.gnome.shell.extensions.gsconnect.json-{chrome,mozilla}]
+indent_style = space
+indent_size = 4
+

--- a/webextension/.editorconfig
+++ b/webextension/.editorconfig
@@ -1,0 +1,10 @@
+# Manifests: 2-space indents
+[manifest.*.json]
+indent_style = space
+indent_size = 2
+
+# l10n message files: 4-space indents
+[_locales/**.json]
+indent_style = space
+indent_size = 4
+


### PR DESCRIPTION
Since I noticed that [CONTRIBUTING.md](https://github.com/andyholmes/gnome-shell-extension-gsconnect/blob/master/CONTRIBUTING.md) provided some style guidelines for code in the repo, I thought I'd take a shot at codifying those explicitly, for those of us whose source editors are able to make use of the shared data. So I added an [.editorconfig file](https://editorconfig.org/).

Actually, I added two of them. I tried to go through and formalize as much of the established code style as I could (that's one of the points in CONTRIBUTING.md, in fact!), and the `webextension/` branch of the tree contained a couple of quirks that were easier to specify in a second file under that directory, rather than stuffing it all in the main file.

For the most part these configs should simply be documenting the formatting that the files already exist in, and therefore simply be a means of ensuring that the style be preserved in any future edits.

The only exception to that is the `meson.build` file in the root directory, which it turns out is _currently_ a haphazard mix of 2- and 4-space indents. I picked 2 as the configured default, but it could certainly be changed to 4 if we wanted to standardize on that instead.
