### PR TITLE
Add/update some telephony translator comments

### DIFF
--- a/src/service/plugins/telephony.js
+++ b/src/service/plugins/telephony.js
@@ -19,6 +19,7 @@ var Metadata = {
     ],
     actions: {
         legacyReply: {
+            // TRANSLATORS: Respond to an incoming call via SMS
             label: _('Reply SMS'),
             icon_name: 'sms-symbolic',
 
@@ -27,6 +28,7 @@ var Metadata = {
             outgoing: ['kdeconnect.sms.request']
         },
         muteCall: {
+            // TRANSLATORS: Silence the actively ringing call
             label: _('Mute Call'),
             icon_name: 'audio-volume-muted-symbolic',
 
@@ -187,7 +189,7 @@ var Plugin = GObject.registerClass({
             body = _('Incoming call');
             buttons = [{
                 action: 'muteCall',
-                // TRANSLATORS: Silence the phone ringer
+                // TRANSLATORS: Silence the actively ringing call
                 label: _('Mute'),
                 parameter: null
             }];


### PR DESCRIPTION
@amivaleo pointed out on Crowdin that the translatable strings involving the telephony "Mute" functions need additional context for clarity. So, I expanded one hint, copied it to a second instance of a related string, and added a hint to a third unhinted string.

@andyholmes can you please double-check that I'm _correct_ in my description of the actions involved, particularly for the "Reply SMS" string? I don't want to merge misleading info.