### PR TITLE
Fix notification not shown when payloadTransferInfo is empty

### DIFF
--- a/src/service/__init__.js
+++ b/src/service/__init__.js
@@ -133,6 +133,22 @@ JSON.dump = function (obj, file, sync = false) {
 
 
 /**
+ * A convenience function for checking if a KDE Connect packet has a payload.
+ *
+ * @returns (boolean} - %true if @packet has a payload
+ */
+Object.prototype.hasPayload = function() {
+    if (!this.hasOwnProperty('payloadSize') || this.payloadSize === 0)
+        return false;
+
+    if (!this.hasOwnProperty('payloadTransferInfo'))
+        return false;
+
+    return (Object.keys(this.payloadTransferInfo).length > 0);
+};
+
+
+/**
  * Idle Promise
  *
  * @param {number} priority - The priority of the idle source

--- a/src/service/device.js
+++ b/src/service/device.js
@@ -678,7 +678,7 @@ var Device = GObject.registerClass({
      * @param {Core.Packet} packet - A packet
      */
     async rejectTransfer(packet) {
-        if (!packet || !packet.payloadTransferInfo) return;
+        if (!packet || !packet.hasPayload()) return;
 
         try {
             let transfer = this.createTransfer(Object.assign({

--- a/src/service/plugins/notification.js
+++ b/src/service/plugins/notification.js
@@ -397,7 +397,7 @@ var Plugin = GObject.registerClass({
         let file, path, stream, success, transfer;
 
         try {
-            if (!packet.payloadTransferInfo || !packet.payloadTransferInfo.port) {
+            if (!packet.hasPayload()) {
                 return null;
             }
 

--- a/src/service/plugins/notification.js
+++ b/src/service/plugins/notification.js
@@ -397,7 +397,7 @@ var Plugin = GObject.registerClass({
         let file, path, stream, success, transfer;
 
         try {
-            if (!packet.payloadTransferInfo) {
+            if (!packet.payloadSize) {
                 return null;
             }
 

--- a/src/service/plugins/notification.js
+++ b/src/service/plugins/notification.js
@@ -397,7 +397,7 @@ var Plugin = GObject.registerClass({
         let file, path, stream, success, transfer;
 
         try {
-            if (!packet.payloadSize) {
+            if (!packet.payloadTransferInfo || !packet.payloadTransferInfo.port) {
                 return null;
             }
 


### PR DESCRIPTION
Notification is not shown when send from KDE Connect Desktop / Sailfish Connect and there exists no icon for the notification.

Bug is caused by wrong detection of empty payload in notification plugin. KDE Connect Desktop / Sailfish Connect sends an empty payloadTransferInfo dict when there is no payload and `!{} === false`. Than strange things happen: binary gibberish is send in a new TCP connection to the other side.