### PR TITLE
Remove deprecated public-name

### DIFF
--- a/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
+++ b/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
@@ -10,9 +10,6 @@
     </key>
 
     <!-- Service Settings -->
-    <key name="public-name" type="s">
-      <default>""</default>
-    </key>
     <key name="id" type="s">
       <default>""</default>
     </key>

--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -230,14 +230,6 @@ const Service = GObject.registerClass({
             settings_schema: gsconnect.gschema.lookup(gsconnect.app_id, true)
         });
 
-        // TODO: added v25, remove after a few releases
-        let publicName = this.settings.get_string('public-name');
-
-        if (publicName.length > 0) {
-            this.settings.set_string('name', publicName);
-            this.settings.reset('public-name');
-        }
-
         // Bound Properties
         this.settings.bind('discoverable', this, 'discoverable', 0);
         this.settings.bind('id', this, 'id', 0);


### PR DESCRIPTION
For GSconnect v25, the `public-name` GSettings key was deprecated in favor of `name`.

As part of that deprecation, code was added to `daemon.js` to migrate `public-name` settings to `name`, with a TODO comment saying "remove after a few releases". It's been 9, seems like time.

This PR removes the migration code, and drops `public-name` from the schema, eliminating the last traces of that string from the GSConnect codebase.