### PR TITLE
restore pulseaudio on 'nothing' volume option

### DIFF
--- a/data/ui/device-preferences.ui
+++ b/data/ui/device-preferences.ui
@@ -2476,6 +2476,13 @@
         <attribute name="target">nothing</attribute>
       </item>
       <item>
+        <!-- TRANSLATORS: Restore the system volume -->
+        <attribute name="label" translatable="yes">Restore</attribute>
+        <attribute name="icon">audio-volume-medium-symbolic</attribute>
+        <attribute name="action">settings.ringing-volume</attribute>
+        <attribute name="target">restore</attribute>
+      </item>
+      <item>
         <!-- TRANSLATORS: Lower the system volume -->
         <attribute name="label" translatable="yes">Lower</attribute>
         <attribute name="icon">audio-volume-low-symbolic</attribute>
@@ -2500,6 +2507,13 @@
         <attribute name="icon">audio-volume-medium-symbolic</attribute>
         <attribute name="action">settings.talking-volume</attribute>
         <attribute name="target">nothing</attribute>
+      </item>
+      <item>
+        <!-- TRANSLATORS: Restore the system volume -->
+        <attribute name="label" translatable="yes">Restore</attribute>
+        <attribute name="icon">audio-volume-medium-symbolic</attribute>
+        <attribute name="action">settings.talking-volume</attribute>
+        <attribute name="target">restore</attribute>
       </item>
       <item>
         <!-- TRANSLATORS: Lower the system volume -->

--- a/po/org.gnome.Shell.Extensions.GSConnect.pot
+++ b/po/org.gnome.Shell.Extensions.GSConnect.pot
@@ -280,14 +280,19 @@ msgstr ""
 msgid "Nothing"
 msgstr ""
 
-#. TRANSLATORS: Lower the system volume
+#. TRANSLATORS: Restore the system volume
 #: data/ui/device-preferences.ui:2610 data/ui/device-preferences.ui:2636
+msgid "Restore"
+msgstr ""
+
+#. TRANSLATORS: Lower the system volume
+#: data/ui/device-preferences.ui:2617 data/ui/device-preferences.ui:2643
 msgid "Lower"
 msgstr ""
 
 #. TRANSLATORS: Mute the system volume
 #. TRANSLATORS: Silence the phone ringer
-#: data/ui/device-preferences.ui:2617 data/ui/device-preferences.ui:2643
+#: data/ui/device-preferences.ui:2624 data/ui/device-preferences.ui:2650
 #: src/service/plugins/telephony.js:191
 msgid "Mute"
 msgstr ""

--- a/src/service/plugins/telephony.js
+++ b/src/service/plugins/telephony.js
@@ -94,6 +94,10 @@ var Plugin = GObject.registerClass({
 
         if (pulseaudio) {
             switch (this.settings.get_string(`${eventType}-volume`)) {
+                case 'restore':
+                    pulseaudio.restore();
+                    break;
+
                 case 'lower':
                     pulseaudio.lowerVolume();
                     break;


### PR DESCRIPTION
i'm forwarding call-audio to my fedora machine, so i want to be "notified" of an incoming call by lowering the audio-out, but when i answer the call i want the audio-out to be restored.

i replied to another issue with a bit more detailed description of how i'm forwarding the call-audio
https://github.com/andyholmes/gnome-shell-extension-gsconnect/issues/575#issuecomment-606514700

i'm not sure if this would we a logical thing to do, or that i should add an option to 'restore', instead of using the 'nothing' option for this.