### PR TITLE
Device: create a convenience for launching cancellable subprocesses

### DIFF
--- a/src/service/plugins/runcommand.js
+++ b/src/service/plugins/runcommand.js
@@ -56,19 +56,6 @@ var Plugin = GObject.registerClass({
     _init(device) {
         super._init(device, 'runcommand');
         
-        // Setup a launcher with env variables for commands
-        let application = GLib.build_filenamev([
-            gsconnect.extdatadir,
-            'service',
-            'daemon.js'
-        ]);
-        this._launcher = new Gio.SubprocessLauncher();
-        this._launcher.setenv('GSCONNECT', application, false);
-        this._launcher.setenv('GSCONNECT_DEVICE_ID', this.device.id, false);
-        this._launcher.setenv('GSCONNECT_DEVICE_NAME', this.device.name, false);
-        this._launcher.setenv('GSCONNECT_DEVICE_ICON', this.device.icon_name, false);
-        this._launcher.setenv('GSCONNECT_DEVICE_DBUS', this.device.g_object_path, false);
-
         // Local Commands
         this._commandListChangedId = this.settings.connect(
             'changed::command-list',
@@ -135,22 +122,13 @@ var Plugin = GObject.registerClass({
                 throw new Error(`Unknown command: ${key}`);
             }
             
-            let proc = this._launcher.spawnv([
+            this.device.launchProcess([
                 '/bin/sh',
                 '-c',
                 commandList[key].command
             ]);
-            proc.wait_check_async(null, this._commandExit);
         } catch (e) {
             logError(e, this.device.name);
-        }
-    }
-    
-    _commandExit(proc, res) {
-        try {
-            proc.wait_check_finish(res);
-        } catch (e) {
-            debug(e);
         }
     }
 


### PR DESCRIPTION
Create a per-device subprocess launcher, on-demand, that can be used by
plugins to spawn cancellable subprocesses. If a device becomes unpaired,
it's assumed the device is no longer trusted and all currently running
subprocesses will be automatically reaped.

The runcommand plugin now uses this launcher.

cc #575