### PR TITLE
Enable word-wrap in the Remote Keyboard TextView widget

### DIFF
--- a/src/service/plugins/mousepad.js
+++ b/src/service/plugins/mousepad.js
@@ -474,7 +474,8 @@ var KeyboardInputDialog = GObject.registerClass({
             border_width: 6,
             hexpand: true,
             vexpand: true,
-            visible: true
+            visible: true,
+            wrap_mode: Gtk.WrapMode.WORD_CHAR
         });
         scroll.add(this.text);
 


### PR DESCRIPTION
Currently this widget does not have wrap enabled, which means that with very long text entry, the widget grows in width indefinitely until the user pressed enter (which also inserts a new line on the remote device). This can be annoying, as the window may grow to a length which is wider than the screen.

Instead, this allows long lines of text to wrap independently of newlines and makes entering long paragraphs of text much simpler and more pleasant. Specifically, it enabled the `WORD_CHAR` wrap mode, meaning that text will first wrap to word boundaries, falling back to characters if the word is longer than the textview width.

The window can still be resized for better fit text in the TextView, and for easier entry of longer text.

Before this change:
![Screenshot from 2020-08-13 13-27-08](https://user-images.githubusercontent.com/5883565/90179106-2da0b480-dd6a-11ea-8c5c-e5c57f2923d6.png)

After:
![Screenshot from 2020-08-13 13-33-23](https://user-images.githubusercontent.com/5883565/90179124-342f2c00-dd6a-11ea-9ac4-88ea8e682d48.png)

