### PR TITLE
Clipboard Component, Proxy: refactor to behave more like GtkClipboard

### DIFF
--- a/src/shell/clipboard.js
+++ b/src/shell/clipboard.js
@@ -1,12 +1,13 @@
 'use strict';
 
+const ByteArray = imports.byteArray;
+
 const Gio = imports.gi.Gio;
 const GjsPrivate = imports.gi.GjsPrivate;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 
 const Meta = imports.gi.Meta;
-const St = imports.gi.St;
 
 
 /*
@@ -14,31 +15,54 @@ const St = imports.gi.St;
  */
 const DBUS_NAME = 'org.gnome.Shell.Extensions.GSConnect.Clipboard';
 const DBUS_PATH = '/org/gnome/Shell/Extensions/GSConnect/Clipboard';
-const DBUS_INFO = Gio.DBusInterfaceInfo.new_for_xml(`
+const DBUS_NODE = Gio.DBusNodeInfo.new_for_xml(`
 <node>
   <interface name="org.gnome.Shell.Extensions.GSConnect.Clipboard">
-    <property name="Text" type="s" access="readwrite"/>
+    <!-- Methods -->
+    <method name="GetMimetypes">
+      <arg direction="out" type="as" name="mimetypes"/>
+    </method>
+    <method name="GetText">
+      <arg direction="out" type="s" name="text"/>
+    </method>
+    <method name="SetText">
+      <arg direction="in" type="s" name="text"/>
+    </method>
+    <method name="GetValue">
+      <arg direction="in" type="s" name="mimetype"/>
+      <arg direction="out" type="ay" name="value"/>
+    </method>
+    <method name="SetValue">
+      <arg direction="in" type="ay" name="value"/>
+      <arg direction="in" type="s" name="mimetype"/>
+    </method>
+
+    <!-- Signals -->
+    <signal name="OwnerChange"/>
   </interface>
 </node>
 `);
+const DBUS_INFO = DBUS_NODE.lookup_interface(DBUS_NAME);
 
 
-/* GSConnectShellClipboard:
+/*
+ * Text Mimetypes
+ */
+const TEXT_MIMETYPES = [
+    'text/plain;charset=utf-8',
+    'UTF8_STRING',
+    'text/plain',
+    'STRING',
+];
+
+
+/* GSConnectClipboardPortal:
  *
  * A simple clipboard portal, especially useful on Wayland where GtkClipboard
- * doesn't work in background processes.
+ * doesn't work in the background.
  */
 var Clipboard = GObject.registerClass({
     GTypeName: 'GSConnectShellClipboard',
-    Properties: {
-        'text': GObject.ParamSpec.string(
-            'text',
-            'Text Content',
-            'The current text content of the clipboard',
-            GObject.ParamFlags.READWRITE,
-            ''
-        ),
-    },
 }, class GSConnectShellClipboard extends GjsPrivate.DBusImplementation {
 
     _init(params = {}) {
@@ -46,14 +70,7 @@ var Clipboard = GObject.registerClass({
             g_interface_info: DBUS_INFO,
         });
 
-        this._text = '';
         this._transferring = false;
-
-        // Get the current clipboard content
-        this.clipboard.get_text(
-            St.ClipboardType.CLIPBOARD,
-            this._onTextReceived.bind(this)
-        );
 
         // Watch global selection
         this._selection = global.display.get_selection();
@@ -63,14 +80,9 @@ var Clipboard = GObject.registerClass({
         );
 
         // Prepare DBus interface
-        this._handlePropertyGetId = this.connect(
-            'handle-property-get',
-            this._onHandlePropertyGet.bind(this)
-        );
-
-        this._handlePropertySetId = this.connect(
-            'handle-property-set',
-            this._onHandlePropertySet.bind(this)
+        this._handleMethodCallId = this.connect(
+            'handle-method-call',
+            this._onHandleMethodCall.bind(this)
         );
 
         this._nameId = Gio.DBus.own_name(
@@ -81,46 +93,6 @@ var Clipboard = GObject.registerClass({
             null,
             this._onNameLost.bind(this)
         );
-    }
-
-    get clipboard() {
-        if (this._clipboard === undefined)
-            this._clipboard = St.Clipboard.get_default();
-
-        return this._clipboard;
-    }
-
-    get text() {
-        if (this._text === undefined)
-            this._text = '';
-
-        return this._text;
-    }
-
-    set text(content) {
-        if (typeof content !== 'string')
-            return;
-
-        if (this._text === content)
-            return;
-
-        this._text = content;
-        this.notify('text');
-
-        this.emit_property_changed(
-            'Text',
-            GLib.Variant.new('s', content)
-        );
-    }
-
-    _onTextReceived(clipboard, text) {
-        try {
-            this.text = text;
-        } catch (e) {
-            logError(e);
-        } finally {
-            this._transferring = false;
-        }
     }
 
     _onOwnerChanged(selection, type, source) {
@@ -137,15 +109,13 @@ var Clipboard = GObject.registerClass({
 
         this._transferring = true;
 
-        /* We need to put our transfer call in an idle callback to ensure that
+        /* We need to put our signal emission in an idle callback to ensure that
          * Mutter's internal calls have finished resolving in the loop, or else
          * we'll end up with the previous selection's content.
          */
         GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
-            this.clipboard.get_text(
-                St.ClipboardType.CLIPBOARD,
-                this._onTextReceived.bind(this)
-            );
+            this.emit_signal('OwnerChange', null);
+            this._transferring = false;
 
             return GLib.SOURCE_REMOVE;
         });
@@ -167,55 +137,202 @@ var Clipboard = GObject.registerClass({
         }
     }
 
-    _onHandlePropertyGet(iface, name) {
-        if (name !== 'Text')
-            return;
+    async _onHandleMethodCall(iface, name, parameters, invocation) {
+        let retval;
 
         try {
-            return new GLib.Variant('s', this.text);
+            const args = parameters.recursiveUnpack();
+
+            retval = await this[name](...args);
         } catch (e) {
-            logError(e);
+            if (e instanceof GLib.Error) {
+                invocation.return_gerror(e);
+            } else {
+                if (!e.name.includes('.'))
+                    e.name = `org.gnome.gjs.JSError.${e.name}`;
+
+                invocation.return_dbus_error(e.name, e.message);
+            }
+
+            return;
+        }
+
+        if (retval === undefined)
+            retval = new GLib.Variant('()', []);
+
+        try {
+            if (!(retval instanceof GLib.Variant)) {
+                const args = DBUS_INFO.lookup_method(name).out_args;
+                retval = new GLib.Variant(
+                    `(${args.map(arg => arg.signature).join('')})`,
+                    (args.length === 1) ? [retval] : retval
+                );
+            }
+
+            invocation.return_value(retval);
+
+        // Without a response, the client will wait for timeout
+        } catch (e) {
+            invocation.return_dbus_error(
+                'org.gnome.gjs.JSError.ValueError',
+                'Service implementation returned an incorrect value type'
+            );
         }
     }
 
-    _onHandlePropertySet(iface, name, value) {
-        if (name !== 'Text')
-            return;
+    /**
+     * Get the available mimetypes of the current clipboard content
+     *
+     * @return {Promise<string[]>} A list of mime-types
+     */
+    GetMimetypes() {
+        return new Promise((resolve, reject) => {
+            try {
+                const mimetypes = this._selection.get_mimetypes(
+                    Meta.SelectionType.SELECTION_CLIPBOARD
+                );
 
-        try {
-            let content = value.unpack();
+                resolve(mimetypes);
+            } catch (e) {
+                reject(e);
+            }
+        });
+    }
 
-            if (typeof content !== 'string')
-                return;
+    /**
+     * Get the text content of the clipboard
+     *
+     * @return {Promise<string>} Text content of the clipboard
+     */
+    GetText() {
+        return new Promise((resolve, reject) => {
+            const mimetypes = this._selection.get_mimetypes(
+                Meta.SelectionType.SELECTION_CLIPBOARD);
 
-            if (this._text === content)
-                return;
+            let mimetype = mimetypes.find(type => TEXT_MIMETYPES.includes(type));
 
-            this._text = content;
-            this.notify('text');
+            if (mimetype !== undefined) {
+                const stream = Gio.MemoryOutputStream.new_resizable();
 
-            this.clipboard.set_text(
-                St.ClipboardType.CLIPBOARD,
-                content
+                this._selection.transfer_async(
+                    Meta.SelectionType.SELECTION_CLIPBOARD,
+                    mimetype, -1,
+                    stream, null,
+                    (selection, res) => {
+                        try {
+                            selection.transfer_finish(res);
+
+                            const bytes = stream.steal_as_bytes();
+                            const bytearray = bytes.get_data();
+
+                            resolve(ByteArray.toString(bytearray));
+                        } catch (e) {
+                            reject(e);
+                        }
+                    }
+                );
+            } else {
+                reject(new Error('text not available'));
+            }
+        });
+    }
+
+    /**
+     * Set the text content of the clipboard
+     *
+     * @param {string} text - text content to set
+     * @return {Promise} A promise for the operation
+     */
+    SetText(text) {
+        return new Promise((resolve, reject) => {
+            try {
+                if (typeof text !== 'string') {
+                    throw new Gio.DBusError({
+                        code: Gio.DBusError.INVALID_ARGS,
+                        message: 'expected string',
+                    });
+                }
+
+                const source = Meta.SelectionSourceMemory.new(
+                    'text/plain;charset=utf-8', GLib.Bytes.new(text));
+
+                this._selection.set_owner(
+                    Meta.SelectionType.SELECTION_CLIPBOARD, source);
+
+                resolve();
+            } catch (e) {
+                reject(e);
+            }
+        });
+    }
+
+    /**
+     * Get the content of the clipboard with the type @mimetype.
+     *
+     * @param {string} mimetype - the mimetype to request
+     * @return {Promise<Uint8Array>} The content of the clipboard
+     */
+    GetValue(mimetype) {
+        return new Promise((resolve, reject) => {
+            const stream = Gio.MemoryOutputStream.new_resizable();
+
+            this._selection.transfer_async(
+                Meta.SelectionType.SELECTION_CLIPBOARD,
+                mimetype, -1,
+                stream, null,
+                (selection, res) => {
+                    try {
+                        selection.transfer_finish(res);
+
+                        const bytes = stream.steal_as_bytes();
+
+                        resolve(bytes.get_data());
+                    } catch (e) {
+                        reject(e);
+                    }
+                }
             );
-        } catch (e) {
-            logError(e);
-        }
+        });
+    }
+
+    /**
+     * Set the content of the clipboard to @value with the type @mimetype.
+     *
+     * @param {Uint8Array} value - the value to set
+     * @param {string} mimetype - the mimetype of the value
+     * @return {Promise} - A promise for the operation
+     */
+    SetValue(value, mimetype) {
+        return new Promise((resolve, reject) => {
+            try {
+                const source = Meta.SelectionSourceMemory.new(mimetype,
+                    GLib.Bytes.new(value));
+
+                this._selection.set_owner(
+                    Meta.SelectionType.SELECTION_CLIPBOARD, source);
+
+                resolve();
+            } catch (e) {
+                reject(e);
+            }
+        });
     }
 
     destroy() {
-        if (this.__disposed === undefined) {
+        if (this._selection && this._ownerChangedId > 0) {
             this._selection.disconnect(this._ownerChangedId);
-            this._selection = null;
+            this._ownerChangedId = 0;
+        }
 
+        if (this._nameId > 0) {
             Gio.bus_unown_name(this._nameId);
+            this._nameId = 0;
+        }
 
-            this.flush();
+        if (this._handleMethodCallId > 0) {
+            this.disconnect(this._handleMethodCallId);
+            this._handleMethodCallId = 0;
             this.unexport();
-            this.disconnect(this._handlePropertyGetId);
-            this.disconnect(this._handlePropertySetId);
-
-            GObject.signal_handlers_destroy(this);
         }
     }
 });
@@ -258,11 +375,6 @@ function unwatchService() {
     if (_portalId > 0) {
         Gio.bus_unwatch_name(_portalId);
         _portalId = 0;
-    }
-
-    if (_portal !== null) {
-        _portal.destroy();
-        _portal = null;
     }
 }
 


### PR DESCRIPTION
Refactor the clipboard component to allow dynamically swapping between
GtkClipboard and our custom MetaSelection proxy. Also refactor the proxy
to behave more like GtkClipboard.