### PR TITLE
Explicitly place our menu below the network menu

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -93,7 +93,11 @@ const ServiceIndicator = GObject.registerClass({
         this._item.label.clutter_text.x_expand = true;
         this.menu.addMenuItem(this._item);
 
-        AggregateMenu.menu.addMenuItem(this.menu, 4);
+        // Find current index of network menu
+        let menuItems = AggregateMenu.menu._getMenuItems();
+        let networkMenuIndex = menuItems.indexOf(AggregateMenu._network.menu) || 3;
+        // Place our menu below the network menu
+        AggregateMenu.menu.addMenuItem(this.menu, networkMenuIndex + 1);
 
         // Service Menu -> Devices Section
         this.deviceSection = new PopupMenu.PopupMenuSection();

--- a/src/extension.js
+++ b/src/extension.js
@@ -95,9 +95,10 @@ const ServiceIndicator = GObject.registerClass({
 
         // Find current index of network menu
         let menuItems = AggregateMenu.menu._getMenuItems();
-        let networkMenuIndex = menuItems.indexOf(AggregateMenu._network.menu) || 3;
+        let networkMenuIndex = menuItems.indexOf(AggregateMenu._network.menu);
+        let menuIndex = networkMenuIndex > -1 ? networkMenuIndex : 3;
         // Place our menu below the network menu
-        AggregateMenu.menu.addMenuItem(this.menu, networkMenuIndex + 1);
+        AggregateMenu.menu.addMenuItem(this.menu, menuIndex + 1);
 
         // Service Menu -> Devices Section
         this.deviceSection = new PopupMenu.PopupMenuSection();


### PR DESCRIPTION
On systems where an extension has placed itself at a higher position
than the network menu (for example using an extension that adds more
controls to the volume slider) the AggregateMenu index of '4' would not
be where you expect it.

This change makes it so that we figure out exactly where the network
menu index is and place ourselves right below it.