### PR TITLE
enable 'prefer-const' in eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -192,6 +192,7 @@
         "object-curly-spacing": "error",
         "operator-assignment": "error",
         "operator-linebreak": "error",
+        "prefer-const": "error",
         "prefer-numeric-literals": "error",
         "prefer-promise-reject-errors": "error",
         "prefer-rest-params": "error",

--- a/installed-tests/fixtures/backend.js
+++ b/installed-tests/fixtures/backend.js
@@ -271,6 +271,7 @@ var ChannelService = GObject.registerClass({
         try {
             // Try to parse strings as <host>:<port>
             if (typeof address === 'string') {
+                // eslint-disable-next-line prefer-const
                 let [host, port] = address.split(':');
                 port = parseInt(port) || this.port;
                 address = Gio.InetSocketAddress.new_from_string(host, port);

--- a/installed-tests/fixtures/backend.js
+++ b/installed-tests/fixtures/backend.js
@@ -86,10 +86,10 @@ var ChannelService = GObject.registerClass({
 
     async _onIncomingChannel(listener, connection) {
         try {
-            let host = connection.get_remote_address().address.to_string();
+            const host = connection.get_remote_address().address.to_string();
 
             // Create a channel
-            let channel = new Channel({
+            const channel = new Channel({
                 backend: this,
                 host: host,
                 port: this.port,
@@ -122,8 +122,8 @@ var ChannelService = GObject.registerClass({
             this._udp6.set_broadcast(true);
 
             // Bind the socket
-            let inetAddr = Gio.InetAddress.new_any(Gio.SocketFamily.IPV6);
-            let sockAddr = Gio.InetSocketAddress.new(inetAddr, this.port);
+            const inetAddr = Gio.InetAddress.new_any(Gio.SocketFamily.IPV6);
+            const sockAddr = Gio.InetSocketAddress.new(inetAddr, this.port);
             this._udp6.bind(sockAddr, false);
 
             // Input stream
@@ -157,8 +157,8 @@ var ChannelService = GObject.registerClass({
             this._udp4.set_broadcast(true);
 
             // Bind the socket
-            let inetAddr = Gio.InetAddress.new_any(Gio.SocketFamily.IPV4);
-            let sockAddr = Gio.InetSocketAddress.new(inetAddr, this.port);
+            const inetAddr = Gio.InetAddress.new_any(Gio.SocketFamily.IPV4);
+            const sockAddr = Gio.InetSocketAddress.new(inetAddr, this.port);
             this._udp4.bind(sockAddr, false);
 
             // Input stream
@@ -228,7 +228,7 @@ var ChannelService = GObject.registerClass({
                 return;
 
             // Create a new channel
-            let channel = new Channel({
+            const channel = new Channel({
                 backend: this,
                 host: packet.body.tcpHost,
                 port: packet.body.tcpPort,
@@ -242,12 +242,12 @@ var ChannelService = GObject.registerClass({
             this._channels.set(channel.address, channel);
 
             // Open a TCP connection
-            let connection = await new Promise((resolve, reject) => {
-                let address = Gio.InetSocketAddress.new_from_string(
+            const connection = await new Promise((resolve, reject) => {
+                const address = Gio.InetSocketAddress.new_from_string(
                     packet.body.tcpHost,
                     packet.body.tcpPort
                 );
-                let client = new Gio.SocketClient({enable_proxy: false});
+                const client = new Gio.SocketClient({enable_proxy: false});
 
                 client.connect_async(address, null, (client, res) => {
                     try {
@@ -343,7 +343,7 @@ var ChannelService = GObject.registerClass({
             this._udp4 = null;
         }
 
-        for (let channel of this.channels.values())
+        for (const channel of this.channels.values())
             channel.close();
 
         this._active = false;
@@ -409,7 +409,7 @@ var Channel = GObject.registerClass({
                 this.cancellable,
                 (stream, res) => {
                     try {
-                        let data = stream.read_line_finish_utf8(res)[0];
+                        const data = stream.read_line_finish_utf8(res)[0];
                         this.identity = new Core.Packet(data);
 
                         if (!this.identity.body.deviceId)
@@ -494,10 +494,10 @@ var Channel = GObject.registerClass({
     }
 
     async download(packet, target, cancellable = null) {
-        let connection = await new Promise((resolve, reject) => {
-            let client = new Gio.SocketClient({enable_proxy: false});
+        const connection = await new Promise((resolve, reject) => {
+            const client = new Gio.SocketClient({enable_proxy: false});
 
-            let address = Gio.InetSocketAddress.new_from_string(
+            const address = Gio.InetSocketAddress.new_from_string(
                 this.host,
                 packet.payloadTransferInfo.port
             );
@@ -511,10 +511,10 @@ var Channel = GObject.registerClass({
             });
         });
 
-        let source = connection.get_input_stream();
+        const source = connection.get_input_stream();
 
         // Start the transfer
-        let transferredSize = await this._transfer(source, target, cancellable);
+        const transferredSize = await this._transfer(source, target, cancellable);
 
         if (transferredSize !== packet.payloadSize) {
             throw new Gio.IOErrorEnum({
@@ -526,7 +526,7 @@ var Channel = GObject.registerClass({
 
     async upload(packet, source, size, cancellable = null) {
         // Start listening on the first available port between 1739-1764
-        let listener = new Gio.SocketListener();
+        const listener = new Gio.SocketListener();
         let port = TRANSFER_MIN;
 
         while (port <= TRANSFER_MAX) {
@@ -544,7 +544,7 @@ var Channel = GObject.registerClass({
         }
 
         // Listen for the incoming connection
-        let acceptConnection = new Promise((resolve, reject) => {
+        const acceptConnection = new Promise((resolve, reject) => {
             listener.accept_async(
                 cancellable,
                 (listener, res, source_object) => {
@@ -564,11 +564,11 @@ var Channel = GObject.registerClass({
         this.sendPacket(new Core.Packet(packet));
 
         // Accept the connection and configure the channel
-        let connection = await acceptConnection;
-        let target = connection.get_output_stream();
+        const connection = await acceptConnection;
+        const target = connection.get_output_stream();
 
         // Start the transfer
-        let transferredSize = await this._transfer(source, target, cancellable);
+        const transferredSize = await this._transfer(source, target, cancellable);
 
         if (transferredSize !== size) {
             throw new Gio.IOErrorEnum({
@@ -605,10 +605,10 @@ var Channel = GObject.registerClass({
             if (packet.payloadTransferInfo.port === undefined)
                 return;
 
-            let connection = await new Promise((resolve, reject) => {
-                let client = new Gio.SocketClient({enable_proxy: false});
+            const connection = await new Promise((resolve, reject) => {
+                const client = new Gio.SocketClient({enable_proxy: false});
 
-                let address = Gio.InetSocketAddress.new_from_string(
+                const address = Gio.InetSocketAddress.new_from_string(
                     this.host,
                     packet.payloadTransferInfo.port
                 );

--- a/installed-tests/fixtures/backend.js
+++ b/installed-tests/fixtures/backend.js
@@ -271,9 +271,8 @@ var ChannelService = GObject.registerClass({
         try {
             // Try to parse strings as <host>:<port>
             if (typeof address === 'string') {
-                // eslint-disable-next-line prefer-const
-                let [host, port] = address.split(':');
-                port = parseInt(port) || this.port;
+                const [host, portstr] = address.split(':');
+                const port = parseInt(portstr) || this.port;
                 address = Gio.InetSocketAddress.new_from_string(host, port);
             }
 

--- a/installed-tests/fixtures/components/mpris.js
+++ b/installed-tests/fixtures/components/mpris.js
@@ -21,7 +21,7 @@ const MockMediaPlayer = GObject.registerClass({
      * @param {Object} obj - A dictionary of properties
      */
     update(obj) {
-        for (let [propertyName, propertyValue] of Object.entries(obj))
+        for (const [propertyName, propertyValue] of Object.entries(obj))
             this[`_${propertyName}`] = propertyValue;
 
         // An arbitrary property to notify
@@ -86,7 +86,7 @@ const MockMediaPlayer = GObject.registerClass({
     }
 
     SetPosition(trackId, position) {
-        let offset = this._Position - position;
+        const offset = this._Position - position;
         this.Seek(offset);
     }
 });
@@ -118,7 +118,7 @@ var Component = GObject.registerClass({
     }
 
     addPlayer(identity) {
-        let player = new MockMediaPlayer(identity);
+        const player = new MockMediaPlayer(identity);
 
         player.connect('notify', () => this.emit('player-changed', player));
         player.connect('Seeked', this.emit.bind(this, 'player-seeked'));
@@ -130,7 +130,7 @@ var Component = GObject.registerClass({
     }
 
     removePlayer(identity) {
-        let player = this._players.get(identity);
+        const player = this._players.get(identity);
 
         if (player === undefined)
             return;
@@ -142,7 +142,7 @@ var Component = GObject.registerClass({
     }
 
     getPlayer(identity) {
-        for (let player of this._players.values()) {
+        for (const player of this._players.values()) {
             if (player.Identity === identity)
                 return player;
         }
@@ -151,7 +151,7 @@ var Component = GObject.registerClass({
     }
 
     hasPlayer(identity) {
-        for (let player of this._players.values()) {
+        for (const player of this._players.values()) {
             if (player.Identity === identity)
                 return true;
         }
@@ -160,10 +160,10 @@ var Component = GObject.registerClass({
     }
 
     getIdentities() {
-        let identities = [];
+        const identities = [];
 
-        for (let player of this._players.values()) {
-            let identity = player.Identity;
+        for (const player of this._players.values()) {
+            const identity = player.Identity;
 
             if (identity)
                 identities.push(identity);

--- a/installed-tests/fixtures/components/notification.js
+++ b/installed-tests/fixtures/components/notification.js
@@ -14,7 +14,7 @@ var Component = GObject.registerClass({
 }, class MockListener extends GObject.Object {
 
     fakeNotification(notif) {
-        let variant = GLib.Variant.full_pack(notif);
+        const variant = GLib.Variant.full_pack(notif);
         this.emit('notification-added', variant);
     }
 });

--- a/installed-tests/fixtures/components/pulseaudio.js
+++ b/installed-tests/fixtures/components/pulseaudio.js
@@ -166,7 +166,7 @@ var Component = GObject.registerClass({
     }
 
     lookup_sink(id) {
-        let sink = this._sinks.get(id);
+        const sink = this._sinks.get(id);
 
         return sink || null;
     }

--- a/installed-tests/fixtures/components/session.js
+++ b/installed-tests/fixtures/components/session.js
@@ -27,7 +27,7 @@ var Component = class MockSession {
      * @param {Object} obj - A dictionary of properties
      */
     update(obj) {
-        for (let [propertyName, propertyValue] of Object.entries(obj))
+        for (const [propertyName, propertyValue] of Object.entries(obj))
             this[`_${propertyName}`] = propertyValue;
     }
 };

--- a/installed-tests/fixtures/components/upower.js
+++ b/installed-tests/fixtures/components/upower.js
@@ -39,7 +39,7 @@ var Component = GObject.registerClass({
     }
 
     update(obj) {
-        for (let [propertyName, propertyValue] of Object.entries(obj))
+        for (const [propertyName, propertyValue] of Object.entries(obj))
             this[`_${propertyName}`] = propertyValue;
 
         this.emit('changed');

--- a/installed-tests/fixtures/mpris.js
+++ b/installed-tests/fixtures/mpris.js
@@ -51,7 +51,7 @@ var MockPlayer = GObject.registerClass({
         if (this._ownerId !== 0)
             return;
 
-        let name = this.Identity.replace(/\W*/g, '_');
+        const name = this.Identity.replace(/\W*/g, '_');
 
         this._ownerId = Gio.bus_own_name_on_connection(
             this._connection,

--- a/installed-tests/fixtures/utils.js
+++ b/installed-tests/fixtures/utils.js
@@ -32,8 +32,8 @@ const {ChannelService} = imports.fixtures.backend;
  * File Helpers
  */
 function get_datadir() {
-    let thisPath = /@(.+):\d+/.exec((new Error()).stack.split('\n')[1])[1];
-    let thisFile = Gio.File.new_for_path(thisPath);
+    const thisPath = /@(.+):\d+/.exec((new Error()).stack.split('\n')[1])[1];
+    const thisFile = Gio.File.new_for_path(thisPath);
 
     return thisFile.get_parent().get_parent().get_child('data').get_path();
 }
@@ -112,7 +112,7 @@ function generateIdentity(params = {}) {
         },
     };
 
-    for (let [key, value] of Object.entries(params)) {
+    for (const [key, value] of Object.entries(params)) {
         if (key === 'body')
             Object.assign(identity.body, value);
         else
@@ -131,7 +131,7 @@ function generateIdentity(params = {}) {
  * @return {boolean} %true if the object is a subset
  */
 function isSubset(obj, subset) {
-    for (let [key, val] of Object.entries(subset)) {
+    for (const [key, val] of Object.entries(subset)) {
         if (!obj.hasOwnProperty(key))
             return false;
 
@@ -176,7 +176,7 @@ function isSubset(obj, subset) {
  */
 async function _awaitPacket(type, body = null) {
     while (true) {
-        for (let [packet] of this.handlePacket.calls.allArgs()) {
+        for (const [packet] of this.handlePacket.calls.allArgs()) {
             if (packet.type !== type)
                 continue;
 
@@ -208,7 +208,7 @@ function isolateDirectories() {
     Config.CONFIGDIR = GLib.build_filenamev([tmpdir, 'config']);
     Config.RUNTIMEDIR = GLib.build_filenamev([tmpdir, 'runtime']);
 
-    for (let path of [Config.CACHEDIR, Config.CONFIGDIR, Config.RUNTIMEDIR])
+    for (const path of [Config.CACHEDIR, Config.CONFIGDIR, Config.RUNTIMEDIR])
         GLib.mkdir_with_parents(path, 0o755);
 
     return tmpdir;

--- a/installed-tests/suites/backends/testLanBackend.js
+++ b/installed-tests/suites/backends/testLanBackend.js
@@ -85,7 +85,7 @@ describe('A LAN channel service', function () {
 
     describe('produces channels', function () {
         it('that can transfer packets', async function () {
-            let outgoingPacket = new Core.Packet({
+            const outgoingPacket = new Core.Packet({
                 type: 'kdeconnect.test',
                 body: {
                     foo: GLib.uuid_string_random(),
@@ -93,7 +93,7 @@ describe('A LAN channel service', function () {
             });
             await localChannel.sendPacket(outgoingPacket);
 
-            let incomingPacket = await remoteChannel.readPacket();
+            const incomingPacket = await remoteChannel.readPacket();
             expect(incomingPacket.type).toBe(outgoingPacket.type);
             expect(incomingPacket.body.foo).toBe(outgoingPacket.body.foo);
         });

--- a/installed-tests/suites/components/testMprisComponent.js
+++ b/installed-tests/suites/components/testMprisComponent.js
@@ -100,7 +100,7 @@ describe('The MPRIS component', function () {
         });
 
         it('and retrieve them', function () {
-            let proxy = manager.getPlayer(player.Identity);
+            const proxy = manager.getPlayer(player.Identity);
             expect(proxy.Identity).toBe(player.Identity);
         });
 

--- a/installed-tests/suites/core/testPlugin.js
+++ b/installed-tests/suites/core/testPlugin.js
@@ -229,7 +229,7 @@ describe('Plugin packets', function () {
     });
 
     it('can be received if supported', function () {
-        let packet = {
+        const packet = {
             type: 'kdeconnect.foo',
             body: {},
         };

--- a/installed-tests/suites/plugins/testBatteryPlugin.js
+++ b/installed-tests/suites/plugins/testBatteryPlugin.js
@@ -114,8 +114,8 @@ describe('The battery plugin', function () {
     });
 
     it('updates the GAction state', function () {
-        let batteryAction = remotePlugin.device.lookup_action('battery');
-        let [charging, icon, level, time] = batteryAction.state.deepUnpack();
+        const batteryAction = remotePlugin.device.lookup_action('battery');
+        const [charging, icon, level, time] = batteryAction.state.deepUnpack();
 
         expect(charging).toBeFalse();
         expect(icon).toBe('battery-good-symbolic');

--- a/installed-tests/suites/plugins/testContactsPlugin.js
+++ b/installed-tests/suites/plugins/testContactsPlugin.js
@@ -36,10 +36,10 @@ function handlePacket(packet) {
         this.sendPacket(Packets.uidsResponse);
 
     } else if (packet.type === 'kdeconnect.contacts.request_vcards_by_uid') {
-        let response = Packets.vcardsResponse;
+        const response = Packets.vcardsResponse;
         response.body = {uids: packet.body.uids};
 
-        for (let uid of response.body.uids)
+        for (const uid of response.body.uids)
             response.body[uid] = VCards[uid];
 
         this.sendPacket(response);

--- a/installed-tests/suites/plugins/testNotificationPlugin.js
+++ b/installed-tests/suites/plugins/testNotificationPlugin.js
@@ -120,7 +120,7 @@ describe('The notification plugin', function () {
     it('enables its GActions when connected', function () {
         testRig.setConnected(true);
 
-        for (let action in localPlugin._meta.actions)
+        for (const action in localPlugin._meta.actions)
             expect(localPlugin.device.get_action_enabled(action)).toBeTrue();
     });
 
@@ -184,8 +184,8 @@ describe('The notification plugin', function () {
         });
 
         it('when sending for the application is not allowed', function () {
-            let applications = localPlugin.settings.get_string('applications');
-            let disabled = JSON.parse(applications);
+            const applications = localPlugin.settings.get_string('applications');
+            const disabled = JSON.parse(applications);
             disabled['Application'].enabled = false;
             localPlugin.settings.set_string('applications',
                 JSON.stringify(disabled));
@@ -280,10 +280,10 @@ describe('The notification plugin', function () {
     it('disables its GActions when disconnected', function () {
         testRig.setConnected(false);
 
-        for (let action in localPlugin._meta.actions)
+        for (const action in localPlugin._meta.actions)
             expect(localPlugin.device.get_action_enabled(action)).toBeFalse();
 
-        for (let action in remotePlugin._meta.actions)
+        for (const action in remotePlugin._meta.actions)
             expect(remotePlugin.device.get_action_enabled(action)).toBeFalse();
     });
 });

--- a/installed-tests/suites/plugins/testSharePlugin.js
+++ b/installed-tests/suites/plugins/testSharePlugin.js
@@ -52,10 +52,10 @@ describe('The share plugin', function () {
     it('enables its GActions when connected', function () {
         testRig.setConnected(true);
 
-        for (let action in localPlugin._meta.actions)
+        for (const action in localPlugin._meta.actions)
             expect(localPlugin.device.get_action_enabled(action)).toBeTrue();
 
-        for (let action in remotePlugin._meta.actions)
+        for (const action in remotePlugin._meta.actions)
             expect(remotePlugin.device.get_action_enabled(action)).toBeTrue();
     });
 
@@ -110,10 +110,10 @@ describe('The share plugin', function () {
     it('disables its GActions when disconnected', function () {
         testRig.setConnected(false);
 
-        for (let action in localPlugin._meta.actions)
+        for (const action in localPlugin._meta.actions)
             expect(localPlugin.device.get_action_enabled(action)).toBeFalse();
 
-        for (let action in remotePlugin._meta.actions)
+        for (const action in remotePlugin._meta.actions)
             expect(remotePlugin.device.get_action_enabled(action)).toBeFalse();
     });
 });

--- a/installed-tests/suites/plugins/testSmsPlugin.js
+++ b/installed-tests/suites/plugins/testSmsPlugin.js
@@ -204,7 +204,7 @@ describe('The sms plugin', function () {
 
         testRig.setConnected(true);
 
-        for (let action in localPlugin._meta.actions)
+        for (const action in localPlugin._meta.actions)
             expect(localPlugin.device.get_action_enabled(action)).toBeTrue();
     });
 
@@ -269,7 +269,7 @@ describe('The sms plugin', function () {
     it('disables its GActions when disconnected', function () {
         testRig.setConnected(false);
 
-        for (let action in localPlugin._meta.actions)
+        for (const action in localPlugin._meta.actions)
             expect(localPlugin.device.get_action_enabled(action)).toBeFalse();
     });
 });

--- a/src/extension.js
+++ b/src/extension.js
@@ -94,9 +94,9 @@ const ServiceIndicator = GObject.registerClass({
         this.menu.addMenuItem(this._item);
 
         // Find current index of network menu
-        let menuItems = AggregateMenu.menu._getMenuItems();
-        let networkMenuIndex = menuItems.indexOf(AggregateMenu._network.menu);
-        let menuIndex = networkMenuIndex > -1 ? networkMenuIndex : 3;
+        const menuItems = AggregateMenu.menu._getMenuItems();
+        const networkMenuIndex = menuItems.indexOf(AggregateMenu._network.menu);
+        const menuIndex = networkMenuIndex > -1 ? networkMenuIndex : 3;
         // Place our menu below the network menu
         AggregateMenu.menu.addMenuItem(this.menu, menuIndex + 1);
 
@@ -140,7 +140,7 @@ const ServiceIndicator = GObject.registerClass({
 
     _enable() {
         try {
-            let enabled = this.settings.get_boolean('enabled');
+            const enabled = this.settings.get_boolean('enabled');
 
             // If the service state matches the enabled setting, we should
             // toggle the service by toggling the setting
@@ -162,29 +162,29 @@ const ServiceIndicator = GObject.registerClass({
     }
 
     _sync() {
-        let available = this.service.devices.filter(device => {
+        const available = this.service.devices.filter(device => {
             return (device.connected && device.paired);
         });
-        let panelMode = this.settings.get_boolean('show-indicators');
+        const panelMode = this.settings.get_boolean('show-indicators');
 
         // Hide status indicator if in Panel mode or no devices are available
         this._indicator.visible = (!panelMode && available.length);
 
         // Show device indicators in Panel mode if available
-        for (let device of this.service.devices) {
-            let isAvailable = available.includes(device);
-            let indicator = Main.panel.statusArea[device.g_object_path];
+        for (const device of this.service.devices) {
+            const isAvailable = available.includes(device);
+            const indicator = Main.panel.statusArea[device.g_object_path];
 
             indicator.visible = panelMode && isAvailable;
 
-            let menu = this._menus[device.g_object_path];
+            const menu = this._menus[device.g_object_path];
             menu.actor.visible = !panelMode && isAvailable;
             menu._title.actor.visible = !panelMode && isAvailable;
         }
 
         // One connected device in User Menu mode
         if (!panelMode && available.length === 1) {
-            let device = available[0];
+            const device = available[0];
 
             // Hide the menu title and move it to the submenu item
             this._menus[device.g_object_path]._title.actor.visible = false;
@@ -229,7 +229,7 @@ const ServiceIndicator = GObject.registerClass({
 
     _onDeviceChanged(device, changed, invalidated) {
         try {
-            let properties = changed.deepUnpack();
+            const properties = changed.deepUnpack();
 
             if (properties.hasOwnProperty('Connected') ||
                 properties.hasOwnProperty('Paired'))
@@ -242,11 +242,11 @@ const ServiceIndicator = GObject.registerClass({
     _onDeviceAdded(service, device) {
         try {
             // Device Indicator
-            let indicator = new Device.Indicator({device: device});
+            const indicator = new Device.Indicator({device: device});
             Main.panel.addToStatusArea(device.g_object_path, indicator);
 
             // Device Menu
-            let menu = new Device.Menu({
+            const menu = new Device.Menu({
                 device: device,
                 menu_type: 'list',
             });
@@ -316,13 +316,13 @@ const ServiceIndicator = GObject.registerClass({
             device._keybindings = [];
 
             // Get the keybindings
-            let keybindings = device.settings.get_value('keybindings').deepUnpack();
+            const keybindings = device.settings.get_value('keybindings').deepUnpack();
 
             // Apply the keybindings
-            for (let [action, accelerator] of Object.entries(keybindings)) {
-                let [, name, parameter] = Gio.Action.parse_detailed_name(action);
+            for (const [action, accelerator] of Object.entries(keybindings)) {
+                const [, name, parameter] = Gio.Action.parse_detailed_name(action);
 
-                let actionId = this._keybindings.add(
+                const actionId = this._keybindings.add(
                     accelerator,
                     () => device.action_group.activate_action(name, parameter)
                 );
@@ -371,7 +371,7 @@ const ServiceIndicator = GObject.registerClass({
             this.service.disconnect(this._deviceAddedId);
             this.service.disconnect(this._deviceRemovedId);
 
-            for (let device of this.service.devices)
+            for (const device of this.service.devices)
                 this._onDeviceRemoved(this.service, device, false);
 
             this.service.destroy();

--- a/src/preferences/device.js
+++ b/src/preferences/device.js
@@ -14,14 +14,14 @@ const Keybindings = imports.preferences.keybindings;
 const DEVICE_PLUGINS = [];
 const DEVICE_SHORTCUTS = {};
 
-for (let name in imports.service.plugins) {
-    let module = imports.service.plugins[name];
+for (const name in imports.service.plugins) {
+    const module = imports.service.plugins[name];
 
     // Plugins
     DEVICE_PLUGINS.push(name);
 
     // Shortcuts (GActions without parameters)
-    for (let [name, action] of Object.entries(module.Metadata.actions)) {
+    for (const [name, action] of Object.entries(module.Metadata.actions)) {
         if (action.parameter_type === null)
             DEVICE_SHORTCUTS[name] = [action.icon_name, action.label];
     }
@@ -35,7 +35,7 @@ for (let name in imports.service.plugins) {
  * @param {Gtk.ListBoxRow} before - The previous row
  */
 function rowSeparators(row, before) {
-    let header = row.get_header();
+    const header = row.get_header();
 
     if (before === null) {
         if (header !== null)
@@ -344,12 +344,12 @@ var Panel = GObject.registerClass({
     }
 
     get_incoming_supported(type) {
-        let incoming = this.settings.get_strv('incoming-capabilities');
+        const incoming = this.settings.get_strv('incoming-capabilities');
         return incoming.includes(`kdeconnect.${type}`);
     }
 
     get_outgoing_supported(type) {
-        let outgoing = this.settings.get_strv('outgoing-capabilities');
+        const outgoing = this.settings.get_strv('outgoing-capabilities');
         return outgoing.includes(`kdeconnect.${type}`);
     }
 
@@ -373,12 +373,12 @@ var Panel = GObject.registerClass({
     }
 
     _onToggleRowActivated(box, row) {
-        let widget = row.get_child().get_child_at(1, 0);
+        const widget = row.get_child().get_child_at(1, 0);
         widget.active = !widget.active;
     }
 
     _onEncryptionInfo() {
-        let dialog = new Gtk.MessageDialog({
+        const dialog = new Gtk.MessageDialog({
             buttons: Gtk.ButtonsType.OK,
             text: _('Encryption Info'),
             secondary_text: this.device.encryption_info,
@@ -402,7 +402,7 @@ var Panel = GObject.registerClass({
         this.device.action_group.disconnect(this._actionRemovedId);
 
         // GSettings
-        for (let settings of Object.values(this._pluginSettings))
+        for (const settings of Object.values(this._pluginSettings))
             settings.run_dispose();
 
         this.settings.disconnect(this._keybindingsId);
@@ -416,7 +416,7 @@ var Panel = GObject.registerClass({
             this._pluginSettings = {};
 
         if (!this._pluginSettings.hasOwnProperty(name)) {
-            let meta = imports.service.plugins[name].Metadata;
+            const meta = imports.service.plugins[name].Metadata;
 
             this._pluginSettings[name] = new Gio.Settings({
                 settings_schema: Config.GSCHEMA.lookup(meta.id, -1),
@@ -476,16 +476,16 @@ var Panel = GObject.registerClass({
         this.actions.add_action(settings.create_action('talking-microphone'));
 
         // Pair Actions
-        let encryption_info = new Gio.SimpleAction({name: 'encryption-info'});
+        const encryption_info = new Gio.SimpleAction({name: 'encryption-info'});
         encryption_info.connect('activate', this._onEncryptionInfo.bind(this));
         this.actions.add_action(encryption_info);
 
-        let status_pair = new Gio.SimpleAction({name: 'pair'});
+        const status_pair = new Gio.SimpleAction({name: 'pair'});
         status_pair.connect('activate', this._deviceAction.bind(this.device));
         this.settings.bind('paired', status_pair, 'enabled', 16);
         this.actions.add_action(status_pair);
 
-        let status_unpair = new Gio.SimpleAction({name: 'unpair'});
+        const status_unpair = new Gio.SimpleAction({name: 'unpair'});
         status_unpair.connect('activate', this._deviceAction.bind(this.device));
         this.settings.bind('paired', status_unpair, 'enabled', 0);
         this.actions.add_action(status_unpair);
@@ -496,7 +496,7 @@ var Panel = GObject.registerClass({
      */
     _sharingSettings() {
         // Share Plugin
-        let settings = this.pluginSettings('share');
+        const settings = this.pluginSettings('share');
 
         settings.connect(
             'changed::receive-directory',
@@ -506,7 +506,7 @@ var Panel = GObject.registerClass({
 
         // Visibility
         this.desktop_list.foreach(row => {
-            let name = row.get_name();
+            const name = row.get_name();
             row.visible = this.get_outgoing_supported(`${name}.request`);
         });
 
@@ -521,7 +521,7 @@ var Panel = GObject.registerClass({
         this.share_list.set_header_func(rowSeparators);
 
         // Scroll with keyboard focus
-        let sharing_box = this.sharing_page.get_child().get_child();
+        const sharing_box = this.sharing_page.get_child().get_child();
         sharing_box.set_focus_vadjustment(this.sharing_page.vadjustment);
 
         // Continue focus chain between lists
@@ -538,7 +538,7 @@ var Panel = GObject.registerClass({
             );
 
             // Account for some corner cases with a fallback
-            let homeDir = GLib.get_home_dir();
+            const homeDir = GLib.get_home_dir();
 
             if (!receiveDir || receiveDir === homeDir)
                 receiveDir = GLib.build_filenamev([homeDir, 'Downloads']);
@@ -551,9 +551,9 @@ var Panel = GObject.registerClass({
     }
 
     _onReceiveDirectorySet(button) {
-        let settings = this.pluginSettings('share');
-        let receiveDir = settings.get_string('receive-directory');
-        let filename = button.get_filename();
+        const settings = this.pluginSettings('share');
+        const receiveDir = settings.get_string('receive-directory');
+        const filename = button.get_filename();
 
         if (filename !== receiveDir)
             settings.set_string('receive-directory', filename);
@@ -575,7 +575,7 @@ var Panel = GObject.registerClass({
             }
 
             // Check UPower for a battery
-            let hasBattery = await new Promise((resolve, reject) => {
+            const hasBattery = await new Promise((resolve, reject) => {
                 Gio.DBus.system.call(
                     'org.freedesktop.UPower',
                     '/org/freedesktop/UPower/devices/DisplayDevice',
@@ -591,9 +591,9 @@ var Panel = GObject.registerClass({
                     null,
                     (connection, res) => {
                         try {
-                            let variant = connection.call_finish(res);
-                            let value = variant.deepUnpack()[0];
-                            let isPresent = value.get_boolean();
+                            const variant = connection.call_finish(res);
+                            const value = variant.deepUnpack()[0];
+                            const isPresent = value.get_boolean();
 
                             resolve(isPresent);
                         } catch (e) {
@@ -616,17 +616,17 @@ var Panel = GObject.registerClass({
      */
     _runcommandSettings() {
         // Scroll with keyboard focus
-        let runcommand_box = this.runcommand_page.get_child().get_child();
+        const runcommand_box = this.runcommand_page.get_child().get_child();
         runcommand_box.set_focus_vadjustment(this.runcommand_page.vadjustment);
 
         // Local Command List
-        let settings = this.pluginSettings('runcommand');
+        const settings = this.pluginSettings('runcommand');
         this._commands = settings.get_value('command-list').recursiveUnpack();
 
         this.command_list.set_sort_func(this._sortCommands);
         this.command_list.set_header_func(rowSeparators);
 
-        for (let uuid of Object.keys(this._commands))
+        for (const uuid of Object.keys(this._commands))
             this._insertCommand(uuid);
     }
 
@@ -638,7 +638,7 @@ var Panel = GObject.registerClass({
     }
 
     _insertCommand(uuid) {
-        let row = new SectionRow({
+        const row = new SectionRow({
             title: this._commands[uuid].name,
             subtitle: this._commands[uuid].command,
             activatable: false,
@@ -646,7 +646,7 @@ var Panel = GObject.registerClass({
         row.set_name(uuid);
         row.subtitle_label.ellipsize = Pango.EllipsizeMode.MIDDLE;
 
-        let editButton = new Gtk.Button({
+        const editButton = new Gtk.Button({
             image: new Gtk.Image({
                 icon_name: 'document-edit-symbolic',
                 pixel_size: 16,
@@ -661,7 +661,7 @@ var Panel = GObject.registerClass({
         editButton.get_accessible().set_name(_('Edit'));
         row.get_child().attach(editButton, 2, 0, 1, 2);
 
-        let deleteButton = new Gtk.Button({
+        const deleteButton = new Gtk.Button({
             image: new Gtk.Image({
                 icon_name: 'edit-delete-symbolic',
                 pixel_size: 16,
@@ -696,8 +696,8 @@ var Panel = GObject.registerClass({
         }
 
         if (widget instanceof Gtk.Button) {
-            let row = widget.get_ancestor(Gtk.ListBoxRow.$gtype);
-            let uuid = row.get_name();
+            const row = widget.get_ancestor(Gtk.ListBoxRow.$gtype);
+            const uuid = row.get_name();
 
             this._commandEditor.uuid = uuid;
             this._commandEditor.command_name = this._commands[uuid].name;
@@ -712,9 +712,9 @@ var Panel = GObject.registerClass({
     }
 
     _storeCommands() {
-        let variant = {};
+        const variant = {};
 
-        for (let [uuid, command] of Object.entries(this._commands))
+        for (const [uuid, command] of Object.entries(this._commands))
             variant[uuid] = new GLib.Variant('a{ss}', command);
 
         this.pluginSettings('runcommand').set_value(
@@ -724,7 +724,7 @@ var Panel = GObject.registerClass({
     }
 
     _onDeleteCommand(button) {
-        let row = button.get_ancestor(Gtk.ListBoxRow.$gtype);
+        const row = button.get_ancestor(Gtk.ListBoxRow.$gtype);
         delete this._commands[row.get_name()];
         row.destroy();
 
@@ -743,7 +743,7 @@ var Panel = GObject.registerClass({
             //
             let row = null;
 
-            for (let child of this.command_list.get_children()) {
+            for (const child of this.command_list.get_children()) {
                 if (child.get_name() === dialog.uuid) {
                     row = child;
                     break;
@@ -766,7 +766,7 @@ var Panel = GObject.registerClass({
      * Notification Settings
      */
     _notificationSettings() {
-        let settings = this.pluginSettings('notification');
+        const settings = this.pluginSettings('notification');
 
         settings.bind(
             'send-notifications',
@@ -779,7 +779,7 @@ var Panel = GObject.registerClass({
         this.notification_list.set_header_func(rowSeparators);
 
         // Scroll with keyboard focus
-        let notification_box = this.notification_page.get_child().get_child();
+        const notification_box = this.notification_page.get_child().get_child();
         notification_box.set_focus_vadjustment(this.notification_page.vadjustment);
 
         // Continue focus chain between lists
@@ -793,7 +793,7 @@ var Panel = GObject.registerClass({
     }
 
     _onNotificationRowActivated(box, row) {
-        let settings = this.pluginSettings('notification');
+        const settings = this.pluginSettings('notification');
         let applications = {};
 
         try {
@@ -808,10 +808,10 @@ var Panel = GObject.registerClass({
     }
 
     _populateApplications(settings) {
-        let applications = this._queryApplications(settings);
+        const applications = this._queryApplications(settings);
 
-        for (let name in applications) {
-            let row = new SectionRow({
+        for (const name in applications) {
+            const row = new SectionRow({
                 gicon: Gio.Icon.new_for_string(applications[name].iconName),
                 title: name,
                 height_request: 48,
@@ -840,16 +840,16 @@ var Panel = GObject.registerClass({
         }
 
         // Scan applications that statically declare to show notifications
-        let ignoreId = 'org.gnome.Shell.Extensions.GSConnect.desktop';
+        const ignoreId = 'org.gnome.Shell.Extensions.GSConnect.desktop';
 
-        for (let appInfo of Gio.AppInfo.get_all()) {
+        for (const appInfo of Gio.AppInfo.get_all()) {
             if (appInfo.get_id() === ignoreId)
                 continue;
 
             if (!appInfo.get_boolean('X-GNOME-UsesNotifications'))
                 continue;
 
-            let appName = appInfo.get_name();
+            const appName = appInfo.get_name();
 
             if (appName === null || applications.hasOwnProperty(appName))
                 continue;
@@ -885,7 +885,7 @@ var Panel = GObject.registerClass({
      */
     _keybindingSettings() {
         // Scroll with keyboard focus
-        let shortcuts_box = this.shortcuts_page.get_child().get_child();
+        const shortcuts_box = this.shortcuts_page.get_child().get_child();
         shortcuts_box.set_focus_vadjustment(this.shortcuts_page.vadjustment);
 
         // Filter & Sort
@@ -894,7 +894,7 @@ var Panel = GObject.registerClass({
         this.shortcuts_actions_list.set_sort_func(titleSortFunc);
 
         // Init
-        for (let name in DEVICE_SHORTCUTS)
+        for (const name in DEVICE_SHORTCUTS)
             this._addPluginKeybinding(name);
 
         this._setPluginKeybindings();
@@ -915,15 +915,15 @@ var Panel = GObject.registerClass({
     }
 
     _addPluginKeybinding(name) {
-        let [icon_name, label] = DEVICE_SHORTCUTS[name];
+        const [icon_name, label] = DEVICE_SHORTCUTS[name];
 
-        let widget = new Gtk.Label({
+        const widget = new Gtk.Label({
             label: _('Disabled'),
             visible: true,
         });
         widget.get_style_context().add_class('dim-label');
 
-        let row = new SectionRow({
+        const row = new SectionRow({
             height_request: 48,
             icon_name: icon_name,
             title: label,
@@ -939,11 +939,11 @@ var Panel = GObject.registerClass({
     }
 
     _setPluginKeybindings() {
-        let keybindings = this.settings.get_value('keybindings').deepUnpack();
+        const keybindings = this.settings.get_value('keybindings').deepUnpack();
 
         this.shortcuts_actions_list.foreach(row => {
             if (keybindings[row.action]) {
-                let accel = Gtk.accelerator_parse(keybindings[row.action]);
+                const accel = Gtk.accelerator_parse(keybindings[row.action]);
                 row.widget.label = Gtk.accelerator_get_label(...accel);
             } else {
                 row.widget.label = _('Disabled');
@@ -952,9 +952,9 @@ var Panel = GObject.registerClass({
     }
 
     _onResetActionShortcuts(button) {
-        let keybindings = this.settings.get_value('keybindings').deepUnpack();
+        const keybindings = this.settings.get_value('keybindings').deepUnpack();
 
-        for (let action in keybindings) {
+        for (const action in keybindings) {
             // Don't reset remote command shortcuts
             if (!action.includes('::'))
                 delete keybindings[action];
@@ -968,7 +968,7 @@ var Panel = GObject.registerClass({
 
     async _onShortcutRowActivated(box, row) {
         try {
-            let keybindings = this.settings.get_value('keybindings').deepUnpack();
+            const keybindings = this.settings.get_value('keybindings').deepUnpack();
             let accel = keybindings[row.action] || null;
 
             accel = await Keybindings.getAccelerator(row.title, accel);
@@ -992,7 +992,7 @@ var Panel = GObject.registerClass({
      */
     _advancedSettings() {
         // Scroll with keyboard focus
-        let advanced_box = this.advanced_page.get_child().get_child();
+        const advanced_box = this.advanced_page.get_child().get_child();
         advanced_box.set_focus_vadjustment(this.advanced_page.vadjustment);
 
         // Sort & Separate
@@ -1014,7 +1014,7 @@ var Panel = GObject.registerClass({
         );
         this._onPluginsChanged(this.settings, null);
 
-        for (let name of DEVICE_PLUGINS)
+        for (const name of DEVICE_PLUGINS)
             this._addPlugin(name);
     }
 
@@ -1034,9 +1034,9 @@ var Panel = GObject.registerClass({
     }
 
     _addPlugin(name) {
-        let plugin = imports.service.plugins[name];
+        const plugin = imports.service.plugins[name];
 
-        let row = new SectionRow({
+        const row = new SectionRow({
             height_request: 48,
             title: plugin.Metadata.label,
             visible: this._supportedPlugins.includes(name),
@@ -1057,8 +1057,8 @@ var Panel = GObject.registerClass({
     }
 
     _updatePlugins(settings, key) {
-        for (let row of this.plugin_list.get_children()) {
-            let name = row.get_name();
+        for (const row of this.plugin_list.get_children()) {
+            const name = row.get_name();
 
             row.visible = this._supportedPlugins.includes(name);
             row.widget.active = this._enabledPlugins.includes(name);
@@ -1070,8 +1070,8 @@ var Panel = GObject.registerClass({
 
     _togglePlugin(widget) {
         try {
-            let name = widget.get_ancestor(Gtk.ListBoxRow.$gtype).get_name();
-            let index = this._disabledPlugins.indexOf(name);
+            const name = widget.get_ancestor(Gtk.ListBoxRow.$gtype).get_name();
+            const index = this._disabledPlugins.indexOf(name);
 
             // Either add or remove the plugin from the disabled list
             if (index > -1)

--- a/src/preferences/keybindings.js
+++ b/src/preferences/keybindings.js
@@ -143,7 +143,7 @@ var ShortcutChooserDialog = GObject.registerClass({
 
     async _check() {
         try {
-            let available = await checkAccelerator(this.accelerator);
+            const available = await checkAccelerator(this.accelerator);
             this.set_button.visible = available;
             this.conflict_label.visible = !available;
         } catch (e) {
@@ -153,7 +153,7 @@ var ShortcutChooserDialog = GObject.registerClass({
     }
 
     _grab() {
-        let success = this._seat.grab(
+        const success = this._seat.grab(
             this.get_window(),
             Gdk.SeatCapabilities.KEYBOARD,
             true, // owner_events
@@ -210,7 +210,7 @@ async function checkAccelerator(accelerator, modeFlags = 0, grabFlags = 0) {
         let result = false;
 
         // Try to grab the accelerator
-        let action = await new Promise((resolve, reject) => {
+        const action = await new Promise((resolve, reject) => {
             Gio.DBus.session.call(
                 'org.gnome.Shell',
                 '/org/gnome/Shell',
@@ -274,7 +274,7 @@ async function checkAccelerator(accelerator, modeFlags = 0, grabFlags = 0) {
  */
 async function getAccelerator(summary, accelerator = null) {
     try {
-        let dialog = new ShortcutChooserDialog({
+        const dialog = new ShortcutChooserDialog({
             summary: summary,
             accelerator: accelerator,
         });

--- a/src/preferences/service.js
+++ b/src/preferences/service.js
@@ -31,8 +31,8 @@ OS:        ${GLib.get_os_info('PRETTY_NAME')}
  */
 async function generateSupportLog(time) {
     try {
-        let [file, stream] = Gio.File.new_tmp('gsconnect.XXXXXX');
-        let logFile = stream.get_output_stream();
+        const [file, stream] = Gio.File.new_tmp('gsconnect.XXXXXX');
+        const logFile = stream.get_output_stream();
 
         await new Promise((resolve, reject) => {
             logFile.write_bytes_async(LOG_HEADER, 0, null, (file, res) => {
@@ -45,7 +45,7 @@ async function generateSupportLog(time) {
         });
 
         // FIXME: BSD???
-        let proc = new Gio.Subprocess({
+        const proc = new Gio.Subprocess({
             flags: (Gio.SubprocessFlags.STDOUT_PIPE |
                     Gio.SubprocessFlags.STDERR_MERGE),
             argv: ['journalctl', '--no-host', '--since', time],
@@ -76,7 +76,7 @@ async function generateSupportLog(time) {
             });
         });
 
-        let uri = file.get_uri();
+        const uri = file.get_uri();
         Gio.AppInfo.launch_default_for_uri_async(uri, null, null, null);
     } catch (e) {
         logError(e);
@@ -109,8 +109,8 @@ var ConnectDialog = GObject.registerClass({
 
                 // Lan host/port entered
                 if (this.lan_ip.text) {
-                    let host = this.lan_ip.text;
-                    let port = this.lan_port.value;
+                    const host = this.lan_ip.text;
+                    const port = this.lan_port.value;
                     address = GLib.Variant.new_string(`lan://${host}:${port}`);
                 } else {
                     return false;
@@ -129,7 +129,7 @@ var ConnectDialog = GObject.registerClass({
 
 
 function rowSeparators(row, before) {
-    let header = row.get_header();
+    const header = row.get_header();
 
     if (before === null) {
         if (header !== null)
@@ -276,7 +276,7 @@ var Window = GObject.registerClass({
 
     _initMenu() {
         // Panel/User Menu mode
-        let displayMode = new Gio.PropertyAction({
+        const displayMode = new Gio.PropertyAction({
             name: 'display-mode',
             property_name: 'display-mode',
             object: this,
@@ -284,22 +284,22 @@ var Window = GObject.registerClass({
         this.add_action(displayMode);
 
         // About Dialog
-        let aboutDialog = new Gio.SimpleAction({name: 'about'});
+        const aboutDialog = new Gio.SimpleAction({name: 'about'});
         aboutDialog.connect('activate', this._aboutDialog.bind(this));
         this.add_action(aboutDialog);
 
         // "Connect to..." Dialog
-        let connectDialog = new Gio.SimpleAction({name: 'connect'});
+        const connectDialog = new Gio.SimpleAction({name: 'connect'});
         connectDialog.connect('activate', this._connectDialog.bind(this));
         this.add_action(connectDialog);
 
         // "Generate Support Log" GAction
-        let generateSupportLog = new Gio.SimpleAction({name: 'support-log'});
+        const generateSupportLog = new Gio.SimpleAction({name: 'support-log'});
         generateSupportLog.connect('activate', this._generateSupportLog.bind(this));
         this.add_action(generateSupportLog);
 
         // "Help" GAction
-        let help = new Gio.SimpleAction({name: 'help'});
+        const help = new Gio.SimpleAction({name: 'help'});
         help.connect('activate', this._help);
         this.add_action(help);
     }
@@ -328,7 +328,7 @@ var Window = GObject.registerClass({
         });
 
         // Size
-        let [width, height] = this._windowState.get_value('window-size').deepUnpack();
+        const [width, height] = this._windowState.get_value('window-size').deepUnpack();
 
         if (width && height)
             this.set_default_size(width, height);
@@ -339,10 +339,10 @@ var Window = GObject.registerClass({
     }
 
     _saveGeometry() {
-        let state = this.get_window().get_state();
+        const state = this.get_window().get_state();
 
         // Maximized State
-        let maximized = (state & Gdk.WindowState.MAXIMIZED);
+        const maximized = (state & Gdk.WindowState.MAXIMIZED);
         this._windowState.set_boolean('window-maximized', maximized);
 
         // Leave the size at the value before maximizing
@@ -350,7 +350,7 @@ var Window = GObject.registerClass({
             return;
 
         // Size
-        let size = this.get_size();
+        const size = this.get_size();
         this._windowState.set_value('window-size', new GLib.Variant('(ii)', size));
     }
 
@@ -406,7 +406,7 @@ var Window = GObject.registerClass({
      * "Generate Support Log" GAction
      */
     _generateSupportLog() {
-        let dialog = new Gtk.MessageDialog({
+        const dialog = new Gtk.MessageDialog({
             text: _('Generate Support Log'),
             secondary_text: _('Debug messages are being logged. Take any steps necessary to reproduce a problem then review the log.'),
         });
@@ -415,7 +415,7 @@ var Window = GObject.registerClass({
 
         // Enable debug logging and mark the current time
         this.settings.set_boolean('debug', true);
-        let now = GLib.DateTime.new_now_local().format('%R');
+        const now = GLib.DateTime.new_now_local().format('%R');
 
         dialog.connect('response', (dialog, response_id) => {
             // Disable debug logging and destroy the dialog
@@ -434,7 +434,7 @@ var Window = GObject.registerClass({
      * "Help" GAction
      */
     _help(action, parameter) {
-        let uri = `${Config.PACKAGE_URL}/wiki/Help`;
+        const uri = `${Config.PACKAGE_URL}/wiki/Help`;
         Gio.AppInfo.launch_default_for_uri_async(uri, null, null, null);
     }
 
@@ -520,14 +520,14 @@ var Window = GObject.registerClass({
     }
 
     _createDeviceRow(device) {
-        let row = new Gtk.ListBoxRow({
+        const row = new Gtk.ListBoxRow({
             height_request: 52,
             selectable: false,
             visible: true,
         });
         row.set_name(device.id);
 
-        let grid = new Gtk.Grid({
+        const grid = new Gtk.Grid({
             column_spacing: 12,
             margin_left: 20,
             margin_right: 20,
@@ -537,14 +537,14 @@ var Window = GObject.registerClass({
         });
         row.add(grid);
 
-        let icon = new Gtk.Image({
+        const icon = new Gtk.Image({
             gicon: new Gio.ThemedIcon({name: device.icon_name}),
             icon_size: Gtk.IconSize.BUTTON,
             visible: true,
         });
         grid.attach(icon, 0, 0, 1, 1);
 
-        let title = new Gtk.Label({
+        const title = new Gtk.Label({
             halign: Gtk.Align.START,
             hexpand: true,
             valign: Gtk.Align.CENTER,
@@ -553,7 +553,7 @@ var Window = GObject.registerClass({
         });
         grid.attach(title, 1, 0, 1, 1);
 
-        let status = new Gtk.Label({
+        const status = new Gtk.Label({
             halign: Gtk.Align.END,
             hexpand: true,
             valign: Gtk.Align.CENTER,
@@ -588,7 +588,7 @@ var Window = GObject.registerClass({
         try {
             if (!this.stack.get_child_by_name(device.id)) {
                 // Add the device preferences
-                let prefs = new Device.Panel(device);
+                const prefs = new Device.Panel(device);
                 this.stack.add_titled(prefs, device.id, device.name);
 
                 // Add a row to the device list
@@ -602,7 +602,7 @@ var Window = GObject.registerClass({
 
     _onDeviceRemoved(service, device) {
         try {
-            let prefs = this.stack.get_child_by_name(device.id);
+            const prefs = this.stack.get_child_by_name(device.id);
 
             if (prefs === null)
                 return;
@@ -626,8 +626,8 @@ var Window = GObject.registerClass({
                 return this._onPrevious();
 
             // Transition the panel
-            let name = row.get_name();
-            let prefs = this.stack.get_child_by_name(name);
+            const name = row.get_name();
+            const prefs = this.stack.get_child_by_name(name);
 
             this.stack.visible_child = prefs;
             this._setDeviceMenu(prefs);

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -15,7 +15,7 @@ function init() {
 
 function buildPrefsWidget() {
     // Destroy the window once the mainloop starts
-    let widget = new Gtk.Box();
+    const widget = new Gtk.Box();
 
     GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
         widget.get_toplevel().destroy();

--- a/src/service/__init__.js
+++ b/src/service/__init__.js
@@ -31,10 +31,10 @@ if (Config.PACKAGE_DATADIR.startsWith(userDir)) {
         return path.endsWith('/gjs/girepository-1.0');
     }).replace('/gjs/girepository-1.0', '');
 
-    let gsdir = GLib.build_filenamev([libdir, 'gnome-shell']);
+    const gsdir = GLib.build_filenamev([libdir, 'gnome-shell']);
 
     if (!GLib.file_test(gsdir, GLib.FileTest.IS_DIR)) {
-        let currentDir = `/${GLib.path_get_basename(libdir)}`;
+        const currentDir = `/${GLib.path_get_basename(libdir)}`;
         libdir = libdir.replace(currentDir, '');
     }
 
@@ -65,13 +65,13 @@ Config.GSCHEMA = Gio.SettingsSchemaSource.new_from_directory(
 
 // Load DBus interfaces
 Config.DBUS = (() => {
-    let bytes = Gio.resources_lookup_data(
+    const bytes = Gio.resources_lookup_data(
         GLib.build_filenamev([Config.APP_PATH, `${Config.APP_ID}.xml`]),
         Gio.ResourceLookupFlags.NONE
     );
 
-    let xml = ByteArray.toString(bytes.toArray());
-    let dbus = Gio.DBusNodeInfo.new_for_xml(xml);
+    const xml = ByteArray.toString(bytes.toArray());
+    const dbus = Gio.DBusNodeInfo.new_for_xml(xml);
     dbus.nodes.forEach(info => info.cache_build());
 
     return dbus;
@@ -79,7 +79,7 @@ Config.DBUS = (() => {
 
 
 // Init User Directories
-for (let path of [Config.CACHEDIR, Config.CONFIGDIR, Config.RUNTIMEDIR])
+for (const path of [Config.CACHEDIR, Config.CONFIGDIR, Config.RUNTIMEDIR])
     GLib.mkdir_with_parents(path, 0o755);
 
 
@@ -114,8 +114,8 @@ const _debugFunc = function (error, prefix = null) {
     if (prefix)
         message = `${prefix}: ${message}`;
 
-    let [, func, file, line] = _debugCallerMatch.exec(caller);
-    let script = file.replace(Config.PACKAGE_DATADIR, '');
+    const [, func, file, line] = _debugCallerMatch.exec(caller);
+    const script = file.replace(Config.PACKAGE_DATADIR, '');
 
     GLib.log_structured('GSConnect', GLib.LogLevelFlags.LEVEL_MESSAGE, {
         'MESSAGE': `[${script}:${func}:${line}]: ${message}`,
@@ -148,7 +148,7 @@ else
  * @return {string} Return the string stripped of leading 0, and ' ()-+'
  */
 String.prototype.toPhoneNumber = function () {
-    let strippedNumber = this.replace(/^0*|[ ()+-]/g, '');
+    const strippedNumber = this.replace(/^0*|[ ()+-]/g, '');
 
     if (strippedNumber.length)
         return strippedNumber;
@@ -164,8 +164,8 @@ String.prototype.toPhoneNumber = function () {
  * @return {boolean} If `this` and @number are equivalent phone numbers
  */
 String.prototype.equalsPhoneNumber = function (number) {
-    let a = this.toPhoneNumber();
-    let b = number.toPhoneNumber();
+    const a = this.toPhoneNumber();
+    const b = number.toPhoneNumber();
 
     return (a.endsWith(b) || b.endsWith(a));
 };
@@ -182,7 +182,7 @@ Gio.File.rm_rf = function (file) {
             file = Gio.File.new_for_path(file);
 
         try {
-            let iter = file.enumerate_children(
+            const iter = file.enumerate_children(
                 'standard::name',
                 Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
                 null
@@ -213,7 +213,7 @@ Gio.File.rm_rf = function (file) {
  */
 function _full_pack(obj) {
     let packed;
-    let type = typeof obj;
+    const type = typeof obj;
 
     switch (true) {
         case (obj instanceof GLib.Variant):
@@ -246,7 +246,7 @@ function _full_pack(obj) {
         case (type === 'object'):
             packed = {};
 
-            for (let [key, val] of Object.entries(obj)) {
+            for (const [key, val] of Object.entries(obj)) {
                 if (val !== undefined)
                     packed[key] = _full_pack(val);
             }
@@ -269,7 +269,7 @@ GLib.Variant.full_pack = _full_pack;
  */
 function _full_unpack(obj) {
     obj = (obj === undefined) ? this : obj;
-    let unpacked = {};
+    const unpacked = {};
 
     switch (true) {
         case (obj === null):
@@ -285,7 +285,7 @@ function _full_unpack(obj) {
             return obj.map(e => _full_unpack(e));
 
         case (typeof obj === 'object'):
-            for (let [key, value] of Object.entries(obj)) {
+            for (const [key, value] of Object.entries(obj)) {
                 // Try to detect and deserialize GIcons
                 try {
                     if (key === 'icon' && value.get_type_string() === '(sv)')
@@ -323,8 +323,8 @@ GLib.Variant.prototype.full_unpack = _full_unpack;
  */
 Gio.TlsCertificate.new_for_paths = function (certPath, keyPath, commonName = null) {
     // Check if the certificate/key pair already exists
-    let certExists = GLib.file_test(certPath, GLib.FileTest.EXISTS);
-    let keyExists = GLib.file_test(keyPath, GLib.FileTest.EXISTS);
+    const certExists = GLib.file_test(certPath, GLib.FileTest.EXISTS);
+    const keyExists = GLib.file_test(keyPath, GLib.FileTest.EXISTS);
 
     // Create a new certificate and private key if necessary
     if (!certExists || !keyExists) {
@@ -332,7 +332,7 @@ Gio.TlsCertificate.new_for_paths = function (certPath, keyPath, commonName = nul
         if (!commonName)
             commonName = GLib.uuid_string_random();
 
-        let proc = new Gio.Subprocess({
+        const proc = new Gio.Subprocess({
             argv: [
                 Config.OPENSSL_PATH, 'req',
                 '-new', '-x509', '-sha256',
@@ -362,13 +362,13 @@ Object.defineProperties(Gio.TlsCertificate.prototype, {
     'fingerprint': {
         value: function () {
             if (!this.__fingerprint) {
-                let proc = new Gio.Subprocess({
+                const proc = new Gio.Subprocess({
                     argv: [Config.OPENSSL_PATH, 'x509', '-noout', '-fingerprint', '-sha1', '-inform', 'pem'],
                     flags: Gio.SubprocessFlags.STDIN_PIPE | Gio.SubprocessFlags.STDOUT_PIPE,
                 });
                 proc.init(null);
 
-                let stdout = proc.communicate_utf8(this.certificate_pem, null)[1];
+                const stdout = proc.communicate_utf8(this.certificate_pem, null)[1];
                 this.__fingerprint = /[a-zA-Z0-9:]{59}/.exec(stdout)[0];
             }
 
@@ -383,13 +383,13 @@ Object.defineProperties(Gio.TlsCertificate.prototype, {
     'common_name': {
         get: function () {
             if (!this.__common_name) {
-                let proc = new Gio.Subprocess({
+                const proc = new Gio.Subprocess({
                     argv: [Config.OPENSSL_PATH, 'x509', '-noout', '-subject', '-inform', 'pem'],
                     flags: Gio.SubprocessFlags.STDIN_PIPE | Gio.SubprocessFlags.STDOUT_PIPE,
                 });
                 proc.init(null);
 
-                let stdout = proc.communicate_utf8(this.certificate_pem, null)[1];
+                const stdout = proc.communicate_utf8(this.certificate_pem, null)[1];
                 this.__common_name = /(?:cn|CN) ?= ?([^,\n]*)/.exec(stdout)[1];
             }
 

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -399,9 +399,8 @@ var ChannelService = GObject.registerClass({
 
             // Try to parse strings as <host>:<port>
             if (typeof address === 'string') {
-                // eslint-disable-next-line prefer-const
-                let [host, port] = address.split(':');
-                port = parseInt(port) || this.port;
+                const [host, portstr] = address.split(':');
+                const port = parseInt(portstr) || this.port;
                 address = Gio.InetSocketAddress.new_from_string(host, port);
             }
 

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -158,17 +158,17 @@ var ChannelService = GObject.registerClass({
 
     _initCertificate() {
         if (GLib.find_program_in_path(Config.OPENSSL_PATH) === null) {
-            let error = new Error();
+            const error = new Error();
             error.name = _('OpenSSL not found');
             error.url = `${Config.PACKAGE_URL}/wiki/Error#openssl-not-found`;
             throw error;
         }
 
-        let certPath = GLib.build_filenamev([
+        const certPath = GLib.build_filenamev([
             Config.CONFIGDIR,
             'certificate.pem',
         ]);
-        let keyPath = GLib.build_filenamev([
+        const keyPath = GLib.build_filenamev([
             Config.CONFIGDIR,
             'private.pem',
         ]);
@@ -197,10 +197,10 @@ var ChannelService = GObject.registerClass({
 
     async _onIncomingChannel(listener, connection) {
         try {
-            let host = connection.get_remote_address().address.to_string();
+            const host = connection.get_remote_address().address.to_string();
 
             // Create a channel
-            let channel = new Channel({
+            const channel = new Channel({
                 backend: this,
                 certificate: this.certificate,
                 host: host,
@@ -235,8 +235,8 @@ var ChannelService = GObject.registerClass({
             this._udp6.set_broadcast(true);
 
             // Bind the socket
-            let inetAddr = Gio.InetAddress.new_any(Gio.SocketFamily.IPV6);
-            let sockAddr = Gio.InetSocketAddress.new(inetAddr, this.port);
+            const inetAddr = Gio.InetAddress.new_any(Gio.SocketFamily.IPV6);
+            const sockAddr = Gio.InetSocketAddress.new(inetAddr, this.port);
             this._udp6.bind(sockAddr, false);
 
             // Input stream
@@ -270,8 +270,8 @@ var ChannelService = GObject.registerClass({
             this._udp4.set_broadcast(true);
 
             // Bind the socket
-            let inetAddr = Gio.InetAddress.new_any(Gio.SocketFamily.IPV4);
-            let sockAddr = Gio.InetSocketAddress.new(inetAddr, this.port);
+            const inetAddr = Gio.InetAddress.new_any(Gio.SocketFamily.IPV4);
+            const sockAddr = Gio.InetSocketAddress.new(inetAddr, this.port);
             this._udp4.bind(sockAddr, false);
 
             // Input stream
@@ -343,7 +343,7 @@ var ChannelService = GObject.registerClass({
             debug(packet);
 
             // Create a new channel
-            let channel = new Channel({
+            const channel = new Channel({
                 backend: this,
                 certificate: this.certificate,
                 host: packet.body.tcpHost,
@@ -358,12 +358,12 @@ var ChannelService = GObject.registerClass({
             this._channels.set(channel.address, channel);
 
             // Open a TCP connection
-            let connection = await new Promise((resolve, reject) => {
-                let address = Gio.InetSocketAddress.new_from_string(
+            const connection = await new Promise((resolve, reject) => {
+                const address = Gio.InetSocketAddress.new_from_string(
                     packet.body.tcpHost,
                     packet.body.tcpPort
                 );
-                let client = new Gio.SocketClient({enable_proxy: false});
+                const client = new Gio.SocketClient({enable_proxy: false});
 
                 client.connect_async(address, null, (client, res) => {
                     try {
@@ -496,7 +496,7 @@ var ChannelService = GObject.registerClass({
             this._udp4 = null;
         }
 
-        for (let channel of this.channels.values())
+        for (const channel of this.channels.values())
             channel.close();
 
         this._active = false;
@@ -617,7 +617,7 @@ var Channel = GObject.registerClass({
         if (this.device) {
             settings = this.device.settings;
         } else {
-            let id = this.identity.body.deviceId;
+            const id = this.identity.body.deviceId;
             settings = new Gio.Settings({
                 settings_schema: Config.GSCHEMA.lookup(
                     'org.gnome.Shell.Extensions.GSConnect.Device',
@@ -628,7 +628,7 @@ var Channel = GObject.registerClass({
         }
 
         // If we have a certificate for this deviceId, we can verify it
-        let cert_pem = settings.get_string('certificate-pem');
+        const cert_pem = settings.get_string('certificate-pem');
 
         if (cert_pem !== '') {
             let certificate = null;
@@ -661,7 +661,7 @@ var Channel = GObject.registerClass({
                     settings.reset('certificate-pem');
                 }
 
-                let name = this.identity.body.deviceName;
+                const name = this.identity.body.deviceName;
                 throw new Error(`${name}: Authentication Failure`);
             }
         }
@@ -699,7 +699,7 @@ var Channel = GObject.registerClass({
         connection = Gio.TlsServerConnection.new(connection, this.certificate);
 
         // We're the server so we trust-on-first-use and verify after
-        let _id = connection.connect('accept-certificate', (connection) => {
+        const _id = connection.connect('accept-certificate', (connection) => {
             connection.disconnect(_id);
             return true;
         });
@@ -718,7 +718,7 @@ var Channel = GObject.registerClass({
             // In principle this disposable wrapper could buffer more than the
             // identity packet, but in practice the remote device shouldn't send
             // any more data until the TLS connection is negotiated.
-            let stream = new Gio.DataInputStream({
+            const stream = new Gio.DataInputStream({
                 base_stream: connection.input_stream,
                 close_base_stream: false,
             });
@@ -728,7 +728,7 @@ var Channel = GObject.registerClass({
                 this.cancellable,
                 (stream, res) => {
                     try {
-                        let data = stream.read_line_finish_utf8(res)[0];
+                        const data = stream.read_line_finish_utf8(res)[0];
                         stream.close(null);
 
                         // Store the identity as an object property
@@ -835,10 +835,10 @@ var Channel = GObject.registerClass({
     }
 
     async download(packet, target, cancellable = null) {
-        let openConnection = new Promise((resolve, reject) => {
-            let client = new Gio.SocketClient({enable_proxy: false});
+        const openConnection = new Promise((resolve, reject) => {
+            const client = new Gio.SocketClient({enable_proxy: false});
 
-            let address = Gio.InetSocketAddress.new_from_string(
+            const address = Gio.InetSocketAddress.new_from_string(
                 this.host,
                 packet.payloadTransferInfo.port
             );
@@ -854,10 +854,10 @@ var Channel = GObject.registerClass({
 
         let connection = await openConnection;
         connection = await this._encryptClient(connection);
-        let source = connection.get_input_stream();
+        const source = connection.get_input_stream();
 
         // Start the transfer
-        let transferredSize = await this._transfer(source, target, cancellable);
+        const transferredSize = await this._transfer(source, target, cancellable);
 
         if (transferredSize !== packet.payloadSize) {
             throw new Gio.IOErrorEnum({
@@ -869,7 +869,7 @@ var Channel = GObject.registerClass({
 
     async upload(packet, source, size, cancellable = null) {
         // Start listening on the first available port between 1739-1764
-        let listener = new Gio.SocketListener();
+        const listener = new Gio.SocketListener();
         let port = TRANSFER_MIN;
 
         while (port <= TRANSFER_MAX) {
@@ -887,7 +887,7 @@ var Channel = GObject.registerClass({
         }
 
         // Listen for the incoming connection
-        let acceptConnection = new Promise((resolve, reject) => {
+        const acceptConnection = new Promise((resolve, reject) => {
             listener.accept_async(
                 cancellable,
                 (listener, res, source_object) => {
@@ -909,10 +909,10 @@ var Channel = GObject.registerClass({
         // Accept the connection and configure the channel
         let connection = await acceptConnection;
         connection = await this._encryptServer(connection);
-        let target = connection.get_output_stream();
+        const target = connection.get_output_stream();
 
         // Start the transfer
-        let transferredSize = await this._transfer(source, target, cancellable);
+        const transferredSize = await this._transfer(source, target, cancellable);
 
         if (transferredSize !== size) {
             throw new Gio.IOErrorEnum({
@@ -950,9 +950,9 @@ var Channel = GObject.registerClass({
                 return;
 
             let connection = await new Promise((resolve, reject) => {
-                let client = new Gio.SocketClient({enable_proxy: false});
+                const client = new Gio.SocketClient({enable_proxy: false});
 
-                let address = Gio.InetSocketAddress.new_from_string(
+                const address = Gio.InetSocketAddress.new_from_string(
                     this.host,
                     packet.payloadTransferInfo.port
                 );

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -399,6 +399,7 @@ var ChannelService = GObject.registerClass({
 
             // Try to parse strings as <host>:<port>
             if (typeof address === 'string') {
+                // eslint-disable-next-line prefer-const
                 let [host, port] = address.split(':');
                 port = parseInt(port) || this.port;
                 address = Gio.InetSocketAddress.new_from_string(host, port);

--- a/src/service/components/__init__.js
+++ b/src/service/components/__init__.js
@@ -21,7 +21,7 @@ function acquire(name) {
         let info = Default.get(name);
 
         if (info === undefined) {
-            let module = imports.service.components[name];
+            const module = imports.service.components[name];
 
             info = {
                 instance: new module.Component(),
@@ -50,7 +50,7 @@ function acquire(name) {
  */
 function release(name) {
     try {
-        let info = Default.get(name);
+        const info = Default.get(name);
 
         if (info.refcount === 1) {
             info.instance.destroy();

--- a/src/service/components/atspi.js
+++ b/src/service/components/atspi.js
@@ -48,7 +48,7 @@ var Controller = class {
 
         // Try to read modifier keycodes from Gdk
         try {
-            let keymap = Gdk.Keymap.get_for_display(this._display);
+            const keymap = Gdk.Keymap.get_for_display(this._display);
             let modifier;
 
             modifier = keymap.get_entries_for_keyval(Gdk.KEY_Alt_L)[1][0];
@@ -72,9 +72,9 @@ var Controller = class {
      */
     clickPointer(button) {
         try {
-            let [, x, y] = this._pointer.get_position();
-            let monitor = this._display.get_monitor_at_point(x, y);
-            let scale = monitor.get_scale_factor();
+            const [, x, y] = this._pointer.get_position();
+            const monitor = this._display.get_monitor_at_point(x, y);
+            const scale = monitor.get_scale_factor();
             Atspi.generate_mouse_event(scale * x, scale * y, `b${button}c`);
         } catch (e) {
             logError(e);
@@ -83,9 +83,9 @@ var Controller = class {
 
     doubleclickPointer(button) {
         try {
-            let [, x, y] = this._pointer.get_position();
-            let monitor = this._display.get_monitor_at_point(x, y);
-            let scale = monitor.get_scale_factor();
+            const [, x, y] = this._pointer.get_position();
+            const monitor = this._display.get_monitor_at_point(x, y);
+            const scale = monitor.get_scale_factor();
             Atspi.generate_mouse_event(scale * x, scale * y, `b${button}d`);
         } catch (e) {
             logError(e);
@@ -94,9 +94,9 @@ var Controller = class {
 
     movePointer(dx, dy) {
         try {
-            let [, x, y] = this._pointer.get_position();
-            let monitor = this._display.get_monitor_at_point(x, y);
-            let scale = monitor.get_scale_factor();
+            const [, x, y] = this._pointer.get_position();
+            const monitor = this._display.get_monitor_at_point(x, y);
+            const scale = monitor.get_scale_factor();
             Atspi.generate_mouse_event(scale * dx, scale * dy, 'rel');
         } catch (e) {
             logError(e);
@@ -105,9 +105,9 @@ var Controller = class {
 
     pressPointer(button) {
         try {
-            let [, x, y] = this._pointer.get_position();
-            let monitor = this._display.get_monitor_at_point(x, y);
-            let scale = monitor.get_scale_factor();
+            const [, x, y] = this._pointer.get_position();
+            const monitor = this._display.get_monitor_at_point(x, y);
+            const scale = monitor.get_scale_factor();
             Atspi.generate_mouse_event(scale * x, scale * y, `b${button}p`);
         } catch (e) {
             logError(e);
@@ -116,9 +116,9 @@ var Controller = class {
 
     releasePointer(button) {
         try {
-            let [, x, y] = this._pointer.get_position();
-            let monitor = this._display.get_monitor_at_point(x, y);
-            let scale = monitor.get_scale_factor();
+            const [, x, y] = this._pointer.get_position();
+            const monitor = this._display.get_monitor_at_point(x, y);
+            const scale = monitor.get_scale_factor();
             Atspi.generate_mouse_event(scale * x, scale * y, `b${button}r`);
         } catch (e) {
             logError(e);
@@ -245,7 +245,7 @@ var Controller = class {
             this._modeUnlock(XKeycode.Shift_L);
 
             // Enter the unicode sequence
-            let ucode = key.charCodeAt(0).toString(16);
+            const ucode = key.charCodeAt(0).toString(16);
             let keysym;
 
             for (let h = 0, len = ucode.length; h < len; h++) {

--- a/src/service/components/contacts.js
+++ b/src/service/components/contacts.js
@@ -69,7 +69,7 @@ var Store = GObject.registerClass({
      */
     async _parseEContact(econtact, origin = 'desktop') {
         try {
-            let contact = {
+            const contact = {
                 id: econtact.id,
                 name: _('Unknown Contact'),
                 numbers: [],
@@ -82,10 +82,10 @@ var Store = GObject.registerClass({
                 contact.name = econtact.full_name;
 
             // Parse phone numbers
-            let nums = econtact.get_attributes(EBookContacts.ContactField.TEL);
+            const nums = econtact.get_attributes(EBookContacts.ContactField.TEL);
 
-            for (let attr of nums) {
-                let number = {
+            for (const attr of nums) {
+                const number = {
                     value: attr.get_value(),
                     type: 'unknown',
                 };
@@ -101,15 +101,15 @@ var Store = GObject.registerClass({
             }
 
             // Try and get a contact photo
-            let photo = econtact.photo;
+            const photo = econtact.photo;
 
             if (photo) {
                 if (photo.type === EBookContacts.ContactPhotoType.INLINED) {
-                    let data = photo.get_inlined()[0];
+                    const data = photo.get_inlined()[0];
                     contact.avatar = await this.storeAvatar(data);
 
                 } else if (photo.type === EBookContacts.ContactPhotoType.URI) {
-                    let uri = econtact.photo.get_uri();
+                    const uri = econtact.photo.get_uri();
                     contact.avatar = uri.replace('file://', '');
                 }
             }
@@ -177,13 +177,13 @@ var Store = GObject.registerClass({
      */
     _onObjectsAdded(connection, sender, path, iface, signal, params) {
         try {
-            let adds = params.get_child_value(0).get_strv();
+            const adds = params.get_child_value(0).get_strv();
 
             // NOTE: sequential pairs of vcard, id
             for (let i = 0, len = adds.length; i < len; i += 2) {
                 try {
-                    let vcard = adds[i];
-                    let econtact = EBookContacts.Contact.new_from_vcard(vcard);
+                    const vcard = adds[i];
+                    const econtact = EBookContacts.Contact.new_from_vcard(vcard);
                     this._parseEContact(econtact);
                 } catch (e) {
                     debug(e);
@@ -196,9 +196,9 @@ var Store = GObject.registerClass({
 
     _onObjectsRemoved(connection, sender, path, iface, signal, params) {
         try {
-            let changes = params.get_child_value(0).get_strv();
+            const changes = params.get_child_value(0).get_strv();
 
-            for (let id of changes) {
+            for (const id of changes) {
                 try {
                     this.remove(id, false);
                 } catch (e) {
@@ -212,13 +212,13 @@ var Store = GObject.registerClass({
 
     _onObjectsModified(connection, sender, path, iface, signal, params) {
         try {
-            let changes = params.get_child_value(0).get_strv();
+            const changes = params.get_child_value(0).get_strv();
 
             // NOTE: sequential pairs of vcard, id
             for (let i = 0, len = changes.length; i < len; i += 2) {
                 try {
-                    let vcard = changes[i];
-                    let econtact = EBookContacts.Contact.new_from_vcard(vcard);
+                    const vcard = changes[i];
+                    const econtact = EBookContacts.Contact.new_from_vcard(vcard);
                     this._parseEContact(econtact);
                 } catch (e) {
                     debug(e);
@@ -235,13 +235,13 @@ var Store = GObject.registerClass({
     async _onAppeared(watcher, source) {
         try {
             // Get an EBookClient and EBookView
-            let uid = source.get_uid();
-            let client = await this._getEBookClient(source);
-            let view = await this._getEBookView(client, 'exists "tel"');
+            const uid = source.get_uid();
+            const client = await this._getEBookClient(source);
+            const view = await this._getEBookView(client, 'exists "tel"');
 
             // Watch the view for changes to the address book
-            let connection = view.get_connection();
-            let objectPath = view.get_object_path();
+            const connection = view.get_connection();
+            const objectPath = view.get_object_path();
 
             view._objectsAddedId = connection.signal_subscribe(
                 null,
@@ -288,15 +288,15 @@ var Store = GObject.registerClass({
 
     _onDisappeared(watcher, source) {
         try {
-            let uid = source.get_uid();
-            let ebook = this._ebooks.get(uid);
+            const uid = source.get_uid();
+            const ebook = this._ebooks.get(uid);
 
             if (ebook === undefined)
                 return;
 
             // Disconnect the EBookView
             if (ebook.view) {
-                let connection = ebook.view.get_connection();
+                const connection = ebook.view.get_connection();
                 connection.signal_unsubscribe(ebook.view._objectsAddedId);
                 connection.signal_unsubscribe(ebook.view._objectsRemovedId);
                 connection.signal_unsubscribe(ebook.view._objectsModifiedId);
@@ -319,9 +319,9 @@ var Store = GObject.registerClass({
             this._ebooks = new Map();
 
             // Get the current EBooks
-            let registry = await this._getESourceRegistry();
+            const registry = await this._getESourceRegistry();
 
-            for (let source of registry.list_sources('Address Book'))
+            for (const source of registry.list_sources('Address Book'))
                 await this._onAppeared(null, source);
 
             // Watch for new and removed sources
@@ -349,7 +349,7 @@ var Store = GObject.registerClass({
     }
 
     *[Symbol.iterator]() {
-        let contacts = Object.values(this._cacheData);
+        const contacts = Object.values(this._cacheData);
 
         for (let i = 0, len = contacts.length; i < len; i++)
             yield contacts[i];
@@ -385,11 +385,11 @@ var Store = GObject.registerClass({
      */
     storeAvatar(contents) {
         return new Promise((resolve, reject) => {
-            let md5 = GLib.compute_checksum_for_data(
+            const md5 = GLib.compute_checksum_for_data(
                 GLib.ChecksumType.MD5,
                 contents
             );
-            let file = this._cacheDir.get_child(`${md5}`);
+            const file = this._cacheDir.get_child(`${md5}`);
 
             if (file.query_exists(null)) {
                 resolve(file.get_path());
@@ -424,15 +424,15 @@ var Store = GObject.registerClass({
      */
     query(query) {
         // First look for an existing contact by number
-        let contacts = this.contacts;
-        let matches = [];
-        let qnumber = query.number.toPhoneNumber();
+        const contacts = this.contacts;
+        const matches = [];
+        const qnumber = query.number.toPhoneNumber();
 
         for (let i = 0, len = contacts.length; i < len; i++) {
-            let contact = contacts[i];
+            const contact = contacts[i];
 
-            for (let num of contact.numbers) {
-                let cnumber = num.value.toPhoneNumber();
+            for (const num of contact.numbers) {
+                const cnumber = num.value.toPhoneNumber();
 
                 if (qnumber.endsWith(cnumber) || cnumber.endsWith(qnumber)) {
                     // If no query name or exact match, return immediately
@@ -536,11 +536,11 @@ var Store = GObject.registerClass({
      * @return {Object} A dictionary of phone numbers and contacts
      */
     lookupAddresses(addresses) {
-        let contacts = {};
+        const contacts = {};
 
         // Lookup contacts for each address
         for (let i = 0, len = addresses.length; i < len; i++) {
-            let address = addresses[i].address;
+            const address = addresses[i].address;
 
             contacts[address] = this.query({
                 number: address,
@@ -552,7 +552,7 @@ var Store = GObject.registerClass({
 
     async clear() {
         try {
-            let contacts = this.contacts;
+            const contacts = this.contacts;
 
             for (let i = 0, len = contacts.length; i < len; i++)
                 await this.remove(contacts[i].id, false);
@@ -573,8 +573,8 @@ var Store = GObject.registerClass({
             let contacts = Object.values(json);
 
             for (let i = 0, len = contacts.length; i < len; i++) {
-                let new_contact = contacts[i];
-                let contact = this._cacheData[new_contact.id];
+                const new_contact = contacts[i];
+                const contact = this._cacheData[new_contact.id];
 
                 if (!contact || new_contact.timestamp !== contact.timestamp)
                     await this.add(new_contact, false);
@@ -584,7 +584,7 @@ var Store = GObject.registerClass({
             contacts = this.contacts;
 
             for (let i = 0, len = contacts.length; i < len; i++) {
-                let contact = contacts[i];
+                const contact = contacts[i];
 
                 if (!json[contact.id])
                     await this.remove(contact.id, false);
@@ -622,7 +622,7 @@ var Store = GObject.registerClass({
             this._cacheData = await new Promise((resolve, reject) => {
                 this._cacheFile.load_contents_async(null, (file, res) => {
                     try {
-                        let contents = file.load_contents_finish(res)[1];
+                        const contents = file.load_contents_finish(res)[1];
 
                         resolve(JSON.parse(ByteArray.toString(contents)));
                     } catch (e) {
@@ -687,7 +687,7 @@ var Store = GObject.registerClass({
             this._watcher.disconnect(this._disappearedId);
             this._watcher = undefined;
 
-            for (let ebook of this._ebooks.values())
+            for (const ebook of this._ebooks.values())
                 this._onDisappeared(null, ebook.source);
 
             this._edsPrepared = false;

--- a/src/service/components/input.js
+++ b/src/service/components/input.js
@@ -237,7 +237,7 @@ const RemoteSession = GObject.registerClass({
             this.pressKeysym(Gdk.KEY_Super_L);
 
         if (typeof input === 'string') {
-            let keysym = Gdk.unicode_to_keyval(input.codePointAt(0));
+            const keysym = Gdk.unicode_to_keyval(input.codePointAt(0));
             this.pressreleaseKeysym(keysym);
         } else {
             this.pressreleaseKeysym(input);
@@ -301,14 +301,14 @@ class Controller {
         if (HAVE_WAYLAND) {
             // eslint-disable-next-line no-global-assign
             HAVE_REMOTEINPUT = false;
-            let service = Gio.Application.get_default();
+            const service = Gio.Application.get_default();
 
             if (service === null)
                 return true;
 
             // First we're going to disabled the affected plugins on all devices
-            for (let device of service.manager.devices.values()) {
-                let supported = device.settings.get_strv('supported-plugins');
+            for (const device of service.manager.devices.values()) {
+                const supported = device.settings.get_strv('supported-plugins');
                 let index;
 
                 if ((index = supported.indexOf('mousepad')) > -1)
@@ -322,7 +322,7 @@ class Controller {
 
             // Second we need each backend to rebuild its identity packet and
             // broadcast the amended capabilities to the network
-            for (let backend of service.manager.backends.values())
+            for (const backend of service.manager.backends.values())
                 backend.buildIdentity();
 
             service.manager.identify();
@@ -364,7 +364,7 @@ class Controller {
 
     _onSessionExpired() {
         // If the session has been used recently, schedule a new expiry
-        let remainder = Math.floor(this._sessionExpiry - (Date.now() / 1000));
+        const remainder = Math.floor(this._sessionExpiry - (Date.now() / 1000));
 
         if (remainder > 0) {
             this._sessionExpiryId = GLib.timeout_add_seconds(
@@ -418,7 +418,7 @@ class Controller {
             return Promise.reject(new Error('No DBus connection'));
 
         return new Promise((resolve, reject) => {
-            let options = new GLib.Variant('(a{sv})', [{
+            const options = new GLib.Variant('(a{sv})', [{
                 'disable-animations': GLib.Variant.new_boolean(false),
                 'remote-desktop-session-id': GLib.Variant.new_string(sessionId),
             }]);
@@ -462,7 +462,7 @@ class Controller {
                 if (this._checkWayland())
                     return;
 
-                let fallback = imports.service.components.atspi;
+                const fallback = imports.service.components.atspi;
                 this._session = new fallback.Controller();
 
             // Mutter is available and there isn't another session starting
@@ -474,7 +474,7 @@ class Controller {
                 // This takes three steps: creating the remote desktop session,
                 // starting the session, and creating a screencast session for
                 // the remote desktop session.
-                let objectPath = await this._createRemoteDesktopSession();
+                const objectPath = await this._createRemoteDesktopSession();
 
                 this._session = new RemoteSession(objectPath);
                 await this._session.start();

--- a/src/service/components/mpris.js
+++ b/src/service/components/mpris.js
@@ -570,7 +570,7 @@ const PlayerProxy = GObject.registerClass({
         try {
             this.freeze_notify();
 
-            for (let name in changed.deepUnpack())
+            for (const name in changed.deepUnpack())
                 this.notify(name);
 
             this.thaw_notify();
@@ -580,7 +580,7 @@ const PlayerProxy = GObject.registerClass({
     }
 
     initPromise() {
-        let application = new Promise((resolve, reject) => {
+        const application = new Promise((resolve, reject) => {
             this._application.init_async(0, this._cancellable, (proxy, res) => {
                 try {
                     resolve(proxy.init_finish(res));
@@ -590,7 +590,7 @@ const PlayerProxy = GObject.registerClass({
             });
         });
 
-        let player = new Promise((resolve, reject) => {
+        const player = new Promise((resolve, reject) => {
             this._player.init_async(0, this._cancellable, (proxy, res) => {
                 try {
                     resolve(proxy.init_finish(res));
@@ -717,7 +717,7 @@ const PlayerProxy = GObject.registerClass({
     // g-properties-changed is not emitted for this property
     get Position() {
         try {
-            let reply = this._player.call_sync(
+            const reply = this._player.call_sync(
                 'org.freedesktop.DBus.Properties.Get',
                 new GLib.Variant('(ss)', [
                     'org.mpris.MediaPlayer2.Player',
@@ -852,7 +852,7 @@ var Manager = GObject.registerClass({
 
     async _loadPlayers() {
         try {
-            let names = await new Promise((resolve, reject) => {
+            const names = await new Promise((resolve, reject) => {
                 this._connection.call(
                     'org.freedesktop.DBus',
                     '/org/freedesktop/DBus',
@@ -875,7 +875,7 @@ var Manager = GObject.registerClass({
             });
 
             for (let i = 0, len = names.length; i < len; i++) {
-                let name = names[i];
+                const name = names[i];
 
                 if (!name.startsWith('org.mpris.MediaPlayer2'))
                     continue;
@@ -904,7 +904,7 @@ var Manager = GObject.registerClass({
     async _addPlayer(name) {
         try {
             if (!this._players.has(name)) {
-                let player = new PlayerProxy(name);
+                const player = new PlayerProxy(name);
                 await player.initPromise();
 
                 player.connect('notify',
@@ -922,7 +922,7 @@ var Manager = GObject.registerClass({
 
     _removePlayer(name) {
         try {
-            let player = this._players.get(name);
+            const player = this._players.get(name);
 
             if (player !== undefined) {
                 this._paused.delete(name);
@@ -943,7 +943,7 @@ var Manager = GObject.registerClass({
      * @return {boolean} %true if the player was found
      */
     hasPlayer(identity) {
-        for (let player of this._players.values()) {
+        for (const player of this._players.values()) {
             if (player.Identity === identity)
                 return true;
         }
@@ -958,7 +958,7 @@ var Manager = GObject.registerClass({
      * @return {GSConnectMPRISPlayer|null} A player or %null
      */
     getPlayer(identity) {
-        for (let player of this._players.values()) {
+        for (const player of this._players.values()) {
             if (player.Identity === identity)
                 return player;
         }
@@ -972,10 +972,10 @@ var Manager = GObject.registerClass({
      * @return {string[]} A list of player identities
      */
     getIdentities() {
-        let identities = [];
+        const identities = [];
 
-        for (let player of this._players.values()) {
-            let identity = player.Identity;
+        for (const player of this._players.values()) {
+            const identity = player.Identity;
 
             if (identity)
                 identities.push(identity);
@@ -988,7 +988,7 @@ var Manager = GObject.registerClass({
      * A convenience function for pausing all players currently playing.
      */
     pauseAll() {
-        for (let [name, player] of this._players) {
+        for (const [name, player] of this._players) {
             if (player.PlaybackStatus === 'Playing' && player.CanPause) {
                 player.Pause();
                 this._paused.set(name, player);
@@ -1000,7 +1000,7 @@ var Manager = GObject.registerClass({
      * A convenience function for restarting all players paused with pauseAll().
      */
     unpauseAll() {
-        for (let player of this._paused.values()) {
+        for (const player of this._paused.values()) {
             if (player.PlaybackStatus === 'Paused' && player.CanPlay)
                 player.Play();
         }

--- a/src/service/components/notification.js
+++ b/src/service/components/notification.js
@@ -8,7 +8,7 @@ const GObject = imports.gi.GObject;
 const DBus = imports.service.utils.dbus;
 
 
-let _nodeInfo = Gio.DBusNodeInfo.new_for_xml(`
+const _nodeInfo = Gio.DBusNodeInfo.new_for_xml(`
 <node>
   <interface name="org.freedesktop.Notifications">
     <method name="Notify">
@@ -92,13 +92,13 @@ const Listener = GObject.registerClass({
     _onSettingsChanged() {
         this._applications = {};
 
-        for (let app of this._settings.get_strv('application-children')) {
-            let appSettings = new Gio.Settings({
+        for (const app of this._settings.get_strv('application-children')) {
+            const appSettings = new Gio.Settings({
                 schema_id: 'org.gnome.desktop.notifications.application',
                 path: `/org/gnome/desktop/notifications/application/${app}/`,
             });
 
-            let appInfo = Gio.DesktopAppInfo.new(
+            const appInfo = Gio.DesktopAppInfo.new(
                 appSettings.get_string('application-id')
             );
 
@@ -165,19 +165,19 @@ const Listener = GObject.registerClass({
     async _getAppId(sender, appName) {
         try {
             // Get a list of well-known names, ignoring @sender
-            let names = await this._listNames();
+            const names = await this._listNames();
             names.splice(names.indexOf(sender), 1);
 
             // Make a short list for substring matches (fractal/org.gnome.Fractal)
-            let appLower = appName.toLowerCase();
+            const appLower = appName.toLowerCase();
 
-            let shortList = names.filter(name => {
+            const shortList = names.filter(name => {
                 return name.toLowerCase().includes(appLower);
             });
 
             // Run the short list first
-            for (let name of shortList) {
-                let nameOwner = await this._getNameOwner(name);
+            for (const name of shortList) {
+                const nameOwner = await this._getNameOwner(name);
 
                 if (nameOwner === sender)
                     return name;
@@ -186,8 +186,8 @@ const Listener = GObject.registerClass({
             }
 
             // Run the full list
-            for (let name of names) {
-                let nameOwner = await this._getNameOwner(name);
+            for (const name of names) {
+                const nameOwner = await this._getNameOwner(name);
 
                 if (nameOwner === sender)
                     return name;
@@ -213,8 +213,8 @@ const Listener = GObject.registerClass({
             return this._names[appName];
 
         try {
-            let appId = await this._getAppId(sender, appName);
-            let appInfo = Gio.DesktopAppInfo.new(`${appId}.desktop`);
+            const appId = await this._getAppId(sender, appName);
+            const appInfo = Gio.DesktopAppInfo.new(`${appId}.desktop`);
             this._names[appName] = appInfo.get_name();
             appName = appInfo.get_name();
         } catch (e) {
@@ -258,7 +258,7 @@ const Listener = GObject.registerClass({
 
                 // Try to brute-force an application name using DBus
                 if (!this.applications.hasOwnProperty(parameters[0])) {
-                    let sender = message.get_sender();
+                    const sender = message.get_sender();
                     parameters[0] = await this._getAppName(sender, parameters[0]);
                 }
 
@@ -355,14 +355,14 @@ const Listener = GObject.registerClass({
 
     _sendNotification(notif) {
         // Check if this application is disabled in desktop settings
-        let appSettings = this.applications[notif.appName];
+        const appSettings = this.applications[notif.appName];
 
         if (appSettings && !appSettings.get_boolean('enable'))
             return;
 
         // Send the notification to each supporting device
         // TODO: avoid the overhead of the GAction framework with a signal?
-        let variant = GLib.Variant.full_pack(notif);
+        const variant = GLib.Variant.full_pack(notif);
         this.emit('notification-added', variant);
     }
 
@@ -387,7 +387,7 @@ const Listener = GObject.registerClass({
         if (application === 'org.gnome.Shell.Extensions.GSConnect')
             return;
 
-        let appInfo = Gio.DesktopAppInfo.new(`${application}.desktop`);
+        const appInfo = Gio.DesktopAppInfo.new(`${application}.desktop`);
 
         // Try to get an icon for the notification
         if (!notification.hasOwnProperty('icon'))

--- a/src/service/components/pulseaudio.js
+++ b/src/service/components/pulseaudio.js
@@ -10,7 +10,7 @@ const Config = imports.config;
 
 
 // Add gnome-shell's typelib dir to the search path
-let typelibDir = GLib.build_filenamev([Config.GNOME_SHELL_LIBDIR, 'gnome-shell']);
+const typelibDir = GLib.build_filenamev([Config.GNOME_SHELL_LIBDIR, 'gnome-shell']);
 GIRepository.Repository.prepend_search_path(typelibDir);
 GIRepository.Repository.prepend_library_path(typelibDir);
 
@@ -152,7 +152,7 @@ const Mixer = GObject.registerClass({
 
     vfunc_default_sink_changed(id) {
         try {
-            let sink = this.get_default_sink();
+            const sink = this.get_default_sink();
             this._output = (sink) ? new Stream(this, sink) : null;
         } catch (e) {
             logError(e);
@@ -161,7 +161,7 @@ const Mixer = GObject.registerClass({
 
     vfunc_default_source_changed(id) {
         try {
-            let source = this.get_default_source();
+            const source = this.get_default_source();
             this._input = (source) ? new Stream(this, source) : null;
         } catch (e) {
             logError(e);

--- a/src/service/components/session.js
+++ b/src/service/components/session.js
@@ -14,12 +14,12 @@ const Session = class {
 
     async _initAsync() {
         try {
-            let userName = GLib.get_user_name();
-            let sessions = await this._listSessions();
+            const userName = GLib.get_user_name();
+            const sessions = await this._listSessions();
             let sessionPath = '/org/freedesktop/login1/session/auto';
 
             // eslint-disable-next-line no-unused-vars
-            for (let [num, uid, name, seat, objectPath] of sessions) {
+            for (const [num, uid, name, seat, objectPath] of sessions) {
                 if (name === userName) {
                     sessionPath = objectPath;
                     break;
@@ -77,7 +77,7 @@ const Session = class {
     }
 
     async _getSession(objectPath) {
-        let session = new Gio.DBusProxy({
+        const session = new Gio.DBusProxy({
             g_connection: this._connection,
             g_name: 'org.freedesktop.login1',
             g_object_path: objectPath,

--- a/src/service/components/sound.js
+++ b/src/service/components/sound.js
@@ -47,7 +47,7 @@ var Player = class Player {
 
     _canberraPlaySound(name, cancellable) {
         return new Promise((resolve, reject) => {
-            let proc = this._canberra.spawnv(['canberra-gtk-play', '-i', name]);
+            const proc = this._canberra.spawnv(['canberra-gtk-play', '-i', name]);
 
             proc.wait_check_async(cancellable, (proc, res) => {
                 try {
@@ -172,7 +172,7 @@ var Player = class Player {
     }
 
     destroy() {
-        for (let cancellable of this._playing)
+        for (const cancellable of this._playing)
             cancellable.cancel();
     }
 };

--- a/src/service/core.js
+++ b/src/service/core.js
@@ -230,7 +230,7 @@ var Channel = GObject.registerClass({
                 cancellable,
                 (stream, res) => {
                     try {
-                        let data = stream.read_line_finish_utf8(res)[0];
+                        const data = stream.read_line_finish_utf8(res)[0];
 
                         if (data === null) {
                             throw new Gio.IOErrorEnum({
@@ -421,17 +421,17 @@ var ChannelService = GObject.registerClass({
             },
         });
 
-        for (let name in imports.service.plugins) {
+        for (const name in imports.service.plugins) {
             // Exclude mousepad/presenter capability in unsupported sessions
             if (!HAVE_REMOTEINPUT && ['mousepad', 'presenter'].includes(name))
                 continue;
 
-            let meta = imports.service.plugins[name].Metadata;
+            const meta = imports.service.plugins[name].Metadata;
 
-            for (let type of meta.incomingCapabilities)
+            for (const type of meta.incomingCapabilities)
                 this._identity.body.incomingCapabilities.push(type);
 
-            for (let type of meta.outgoingCapabilities)
+            for (const type of meta.outgoingCapabilities)
                 this._identity.body.outgoingCapabilities.push(type);
         }
     }
@@ -584,7 +584,7 @@ var Transfer = GObject.registerClass({
                 return;
 
             if (item.file instanceof Gio.File) {
-                let read = new Promise((resolve, reject) => {
+                const read = new Promise((resolve, reject) => {
                     item.file.read_async(
                         GLib.PRIORITY_DEFAULT,
                         cancellable,
@@ -598,7 +598,7 @@ var Transfer = GObject.registerClass({
                     );
                 });
 
-                let query = new Promise((resolve, reject) => {
+                const query = new Promise((resolve, reject) => {
                     item.file.query_info_async(
                         Gio.FILE_ATTRIBUTE_STANDARD_SIZE,
                         Gio.FileQueryInfoFlags.NONE,
@@ -614,7 +614,7 @@ var Transfer = GObject.registerClass({
                     );
                 });
 
-                let [stream, info] = await Promise.all([read, query]);
+                const [stream, info] = await Promise.all([read, query]);
                 item.source = stream;
                 item.size = info.get_size();
             }
@@ -628,7 +628,7 @@ var Transfer = GObject.registerClass({
      * @param {Gio.File} file - A file to transfer
      */
     addFile(packet, file) {
-        let item = {
+        const item = {
             packet: new Packet(packet),
             file: file,
             source: null,
@@ -645,7 +645,7 @@ var Transfer = GObject.registerClass({
      * @param {string} path - A filepath to transfer
      */
     addPath(packet, path) {
-        let item = {
+        const item = {
             packet: new Packet(packet),
             file: Gio.File.new_for_path(path),
             source: null,
@@ -663,7 +663,7 @@ var Transfer = GObject.registerClass({
      * @param {number} [size] - Payload size
      */
     addStream(packet, stream, size = 0) {
-        let item = {
+        const item = {
             packet: new Packet(packet),
             file: null,
             source: null,

--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -24,7 +24,7 @@ const Gtk = imports.gi.Gtk;
 
 // Bootstrap
 function get_datadir() {
-    let m = /@(.+):\d+/.exec((new Error()).stack.split('\n')[1]);
+    const m = /@(.+):\d+/.exec((new Error()).stack.split('\n')[1]);
     return Gio.File.new_for_path(m[1]).get_parent().get_parent().get_path();
 }
 
@@ -73,7 +73,7 @@ const Service = GObject.registerClass({
      * GActions
      */
     _initActions() {
-        let actions = [
+        const actions = [
             ['connect', this._identify.bind(this), new GLib.VariantType('s')],
             ['device', this._device.bind(this), new GLib.VariantType('(ssbv)')],
             ['error', this._error.bind(this), new GLib.VariantType('a{ss}')],
@@ -82,8 +82,8 @@ const Service = GObject.registerClass({
             ['refresh', this._identify.bind(this), null],
         ];
 
-        for (let [name, callback, type] of actions) {
-            let action = new Gio.SimpleAction({
+        for (const [name, callback, type] of actions) {
+            const action = new Gio.SimpleAction({
                 name: name,
                 parameter_type: type,
             });
@@ -105,7 +105,7 @@ const Service = GObject.registerClass({
 
             // Select the appropriate device(s)
             let devices;
-            let id = parameter[0].unpack();
+            const id = parameter[0].unpack();
 
             if (id === '*')
                 devices = this.manager.devices.values();
@@ -113,10 +113,10 @@ const Service = GObject.registerClass({
                 devices = [this.manager.devices.get(id)];
 
             // Unpack the action data and activate the action
-            let name = parameter[1].unpack();
-            let target = parameter[2].unpack() ? parameter[3].unpack() : null;
+            const name = parameter[1].unpack();
+            const target = parameter[2].unpack() ? parameter[3].unpack() : null;
 
-            for (let device of devices)
+            for (const device of devices)
                 device.activate_action(name, target);
         } catch (e) {
             logError(e);
@@ -125,7 +125,7 @@ const Service = GObject.registerClass({
 
     _error(action, parameter) {
         try {
-            let error = parameter.deepUnpack();
+            const error = parameter.deepUnpack();
 
             // If there's a URL, we have better information in the Wiki
             if (error.url !== undefined) {
@@ -138,7 +138,7 @@ const Service = GObject.registerClass({
                 return;
             }
 
-            let dialog = new ServiceUI.ErrorDialog(error);
+            const dialog = new ServiceUI.ErrorDialog(error);
             dialog.present();
         } catch (e) {
             logError(e);
@@ -177,8 +177,8 @@ const Service = GObject.registerClass({
 
             // Create an new notification
             let id, body, priority;
-            let notif = new Gio.Notification();
-            let icon = new Gio.ThemedIcon({name: 'dialog-error'});
+            const notif = new Gio.Notification();
+            const icon = new Gio.ThemedIcon({name: 'dialog-error'});
             let target = null;
 
             if (error.name === undefined)
@@ -235,7 +235,7 @@ const Service = GObject.registerClass({
         this._serviceMonitor.connect('changed', () => this.quit());
 
         // Init some resources
-        let provider = new Gtk.CssProvider();
+        const provider = new Gtk.CssProvider();
         provider.load_from_resource(`${Config.APP_PATH}/application.css`);
         Gtk.StyleContext.add_provider_for_screen(
             Gdk.Screen.get_default(),
@@ -245,7 +245,7 @@ const Service = GObject.registerClass({
 
         // Ensure our handlers are registered
         try {
-            let appInfo = Gio.DesktopAppInfo.new(`${Config.APP_ID}.desktop`);
+            const appInfo = Gio.DesktopAppInfo.new(`${Config.APP_ID}.desktop`);
             appInfo.add_supports_type('x-scheme-handler/sms');
             appInfo.add_supports_type('x-scheme-handler/tel');
         } catch (e) {
@@ -279,7 +279,7 @@ const Service = GObject.registerClass({
     vfunc_open(files, hint) {
         super.vfunc_open(files, hint);
 
-        for (let file of files) {
+        for (const file of files) {
             let action, parameter, title;
 
             try {
@@ -531,7 +531,7 @@ const Service = GObject.registerClass({
     }
 
     _cliAction(id, name, parameter = null) {
-        let parameters = [];
+        const parameters = [];
 
         if (parameter instanceof GLib.Variant)
             parameters[0] = parameter;
@@ -552,7 +552,7 @@ const Service = GObject.registerClass({
     }
 
     _cliListDevices(full = true) {
-        let result = Gio.DBus.session.call_sync(
+        const result = Gio.DBus.session.call_sync(
             'org.gnome.Shell.Extensions.GSConnect',
             '/org/gnome/Shell/Extensions/GSConnect',
             'org.freedesktop.DBus.ObjectManager',
@@ -564,7 +564,7 @@ const Service = GObject.registerClass({
             null
         );
 
-        let variant = result.unpack()[0].unpack();
+        const variant = result.unpack()[0].unpack();
         let device;
 
         for (let object of Object.values(variant)) {
@@ -583,8 +583,8 @@ const Service = GObject.registerClass({
             throw new TypeError('missing --message-body option');
 
         // TODO: currently we only support single-recipient messaging
-        let addresses = options.lookup_value('message', null).deepUnpack();
-        let body = options.lookup_value('message-body', null).deepUnpack();
+        const addresses = options.lookup_value('message', null).deepUnpack();
+        const body = options.lookup_value('message-body', null).deepUnpack();
 
         this._cliAction(
             id,
@@ -594,7 +594,7 @@ const Service = GObject.registerClass({
     }
 
     _cliNotify(id, options) {
-        let title = options.lookup_value('notification', null).unpack();
+        const title = options.lookup_value('notification', null).unpack();
         let body = '';
         let icon = null;
         let nid = `${Date.now()}`;
@@ -618,7 +618,7 @@ const Service = GObject.registerClass({
             });
         }
 
-        let notification = new GLib.Variant('a{sv}', {
+        const notification = new GLib.Variant('a{sv}', {
             appName: GLib.Variant.new_string(appName),
             id: GLib.Variant.new_string(nid),
             title: GLib.Variant.new_string(title),
@@ -633,7 +633,7 @@ const Service = GObject.registerClass({
     }
 
     _cliShareFile(device, options) {
-        let files = options.lookup_value('share-file', null).deepUnpack();
+        const files = options.lookup_value('share-file', null).deepUnpack();
 
         for (let file of files) {
             file = imports.byteArray.toString(file);
@@ -642,7 +642,7 @@ const Service = GObject.registerClass({
     }
 
     _cliShareLink(device, options) {
-        let uris = options.lookup_value('share-link', null).deepUnpack();
+        const uris = options.lookup_value('share-link', null).deepUnpack();
 
         for (let uri of uris) {
             uri = imports.byteArray.toString(uri);
@@ -651,7 +651,7 @@ const Service = GObject.registerClass({
     }
 
     _cliShareText(device, options) {
-        let text = options.lookup_value('share-text', null).unpack();
+        const text = options.lookup_value('share-text', null).unpack();
 
         this._cliAction(device, 'shareText', GLib.Variant.new_string(text));
     }
@@ -680,7 +680,7 @@ const Service = GObject.registerClass({
             if (!options.contains('device'))
                 return -1;
 
-            let id = options.lookup_value('device', null).unpack();
+            const id = options.lookup_value('device', null).unpack();
 
             // Pairing
             if (options.contains('pair')) {

--- a/src/service/device.js
+++ b/src/service/device.js
@@ -140,13 +140,13 @@ var Device = GObject.registerClass({
     }
 
     get connection_type() {
-        let lastConnection = this.settings.get_string('last-connection');
+        const lastConnection = this.settings.get_string('last-connection');
 
         return lastConnection.split('://')[0];
     }
 
     get contacts() {
-        let contacts = this._plugins.get('contacts');
+        const contacts = this._plugins.get('contacts');
 
         if (contacts && contacts.settings.get_boolean('contacts-source'))
             return contacts._store;
@@ -260,10 +260,10 @@ var Device = GObject.registerClass({
         }
 
         // Packets
-        let incoming = packet.body.incomingCapabilities.sort();
-        let outgoing = packet.body.outgoingCapabilities.sort();
-        let inc = this.settings.get_strv('incoming-capabilities');
-        let out = this.settings.get_strv('outgoing-capabilities');
+        const incoming = packet.body.incomingCapabilities.sort();
+        const outgoing = packet.body.outgoingCapabilities.sort();
+        const inc = this.settings.get_strv('incoming-capabilities');
+        const out = this.settings.get_strv('outgoing-capabilities');
 
         // Only write GSettings if something has changed
         if (incoming.join('') !== inc.join('') || outgoing.join('') !== out.join('')) {
@@ -272,14 +272,14 @@ var Device = GObject.registerClass({
         }
 
         // Determine supported plugins by matching incoming to outgoing types
-        let supported = [];
+        const supported = [];
 
-        for (let name in imports.service.plugins) {
+        for (const name in imports.service.plugins) {
             // Exclude mousepad/presenter plugins in unsupported sessions
             if (!HAVE_REMOTEINPUT && ['mousepad', 'presenter'].includes(name))
                 continue;
 
-            let meta = imports.service.plugins[name].Metadata;
+            const meta = imports.service.plugins[name].Metadata;
 
             // If we can handle packets it sends or send packets it can handle
             if (meta.incomingCapabilities.some(t => outgoing.includes(t)) ||
@@ -288,7 +288,7 @@ var Device = GObject.registerClass({
         }
 
         // Only write GSettings if something has changed
-        let currentSupported = this.settings.get_strv('supported-plugins');
+        const currentSupported = this.settings.get_strv('supported-plugins');
 
         if (currentSupported.join('') !== supported.sort().join(''))
             this.settings.set_strv('supported-plugins', supported);
@@ -368,7 +368,7 @@ var Device = GObject.registerClass({
      */
     launchProcess(args, cancellable = null) {
         if (this._launcher === undefined) {
-            let application = GLib.build_filenamev([
+            const application = GLib.build_filenamev([
                 Config.PACKAGE_DATADIR,
                 'service',
                 'daemon.js',
@@ -387,7 +387,7 @@ var Device = GObject.registerClass({
         }
 
         // Create and track the process
-        let proc = this._launcher.spawnv(args);
+        const proc = this._launcher.spawnv(args);
         proc.wait_check_async(cancellable, this._processExit.bind(this._procs));
         this._procs.add(proc);
 
@@ -409,7 +409,7 @@ var Device = GObject.registerClass({
             if (!this.paired)
                 return this.unpair();
 
-            let handler = this._handlers.get(packet.type);
+            const handler = this._handlers.get(packet.type);
 
             if (handler !== undefined)
                 handler.handlePacket(packet);
@@ -460,23 +460,23 @@ var Device = GObject.registerClass({
      */
     _registerActions() {
         // Pairing notification actions
-        let acceptPair = new Gio.SimpleAction({name: 'pair'});
+        const acceptPair = new Gio.SimpleAction({name: 'pair'});
         acceptPair.connect('activate', this.pair.bind(this));
         this.add_action(acceptPair);
 
-        let rejectPair = new Gio.SimpleAction({name: 'unpair'});
+        const rejectPair = new Gio.SimpleAction({name: 'unpair'});
         rejectPair.connect('activate', this.unpair.bind(this));
         this.add_action(rejectPair);
 
         // Transfer notification actions
-        let cancelTransfer = new Gio.SimpleAction({
+        const cancelTransfer = new Gio.SimpleAction({
             name: 'cancelTransfer',
             parameter_type: new GLib.VariantType('s'),
         });
         cancelTransfer.connect('activate', this.cancelTransfer.bind(this));
         this.add_action(cancelTransfer);
 
-        let openPath = new Gio.SimpleAction({
+        const openPath = new Gio.SimpleAction({
             name: 'openPath',
             parameter_type: new GLib.VariantType('s'),
         });
@@ -484,7 +484,7 @@ var Device = GObject.registerClass({
         this.add_action(openPath);
 
         // Preference helpers
-        let clearCache = new Gio.SimpleAction({
+        const clearCache = new Gio.SimpleAction({
             name: 'clearCache',
             parameter_type: null,
         });
@@ -502,7 +502,7 @@ var Device = GObject.registerClass({
     getMenuAction(actionName) {
         for (let i = 0, len = this.menu.get_n_items(); i < len; i++) {
             try {
-                let val = this.menu.get_item_attribute_value(i, 'action', null);
+                const val = this.menu.get_item_attribute_value(i, 'action', null);
 
                 if (val.unpack() === actionName)
                     return i;
@@ -547,7 +547,7 @@ var Device = GObject.registerClass({
      */
     addMenuAction(action, index = -1, label, icon_name) {
         try {
-            let item = new Gio.MenuItem();
+            const item = new Gio.MenuItem();
 
             if (label)
                 item.set_label(label);
@@ -577,7 +577,7 @@ var Device = GObject.registerClass({
      */
     removeMenuAction(actionName) {
         try {
-            let index = this.getMenuAction(actionName);
+            const index = this.getMenuAction(actionName);
 
             if (index > -1)
                 this.menu.remove(index);
@@ -627,7 +627,7 @@ var Device = GObject.registerClass({
             buttons: [],
         }, params);
 
-        let notif = new Gio.Notification();
+        const notif = new Gio.Notification();
         notif.set_title(params.title);
         notif.set_body(params.body);
         notif.set_icon(params.icon);
@@ -635,7 +635,7 @@ var Device = GObject.registerClass({
 
         // Default Action
         if (params.action) {
-            let hasParameter = (params.action.parameter !== null);
+            const hasParameter = (params.action.parameter !== null);
 
             if (!hasParameter)
                 params.action.parameter = new GLib.Variant('s', '');
@@ -652,8 +652,8 @@ var Device = GObject.registerClass({
         }
 
         // Buttons
-        for (let button of params.buttons) {
-            let hasParameter = (button.parameter !== null);
+        for (const button of params.buttons) {
+            const hasParameter = (button.parameter !== null);
 
             if (!hasParameter)
                 button.parameter = new GLib.Variant('s', '');
@@ -681,8 +681,8 @@ var Device = GObject.registerClass({
      */
     cancelTransfer(action, parameter) {
         try {
-            let uuid = parameter.unpack();
-            let transfer = this._transfers.get(uuid);
+            const uuid = parameter.unpack();
+            const transfer = this._transfers.get(uuid);
 
             if (transfer === undefined)
                 return;
@@ -700,7 +700,7 @@ var Device = GObject.registerClass({
      * @return {Core.Transfer} A new transfer
      */
     createTransfer() {
-        let transfer = new Core.Transfer({device: this});
+        const transfer = new Core.Transfer({device: this});
 
         // Track the transfer
         this._transfers.set(transfer.uuid, transfer);
@@ -726,15 +726,15 @@ var Device = GObject.registerClass({
     }
 
     openPath(action, parameter) {
-        let path = parameter.unpack();
+        const path = parameter.unpack();
 
         // Normalize paths to URIs, assuming local file
-        let uri = path.includes('://') ? path : `file://${path}`;
+        const uri = path.includes('://') ? path : `file://${path}`;
         Gio.AppInfo.launch_default_for_uri_async(uri, null, null, null);
     }
 
     _clearCache(action, parameter) {
-        for (let plugin of this._plugins.values()) {
+        for (const plugin of this._plugins.values()) {
             try {
                 plugin.clearCache();
             } catch (e) {
@@ -850,12 +850,12 @@ var Device = GObject.registerClass({
 
         // If we've become unpaired, stop all subprocesses and transfers
         if (!paired) {
-            for (let proc of this._procs)
+            for (const proc of this._procs)
                 proc.force_exit();
 
             this._procs.clear();
 
-            for (let transfer of this._transfers.values())
+            for (const transfer of this._transfers.values())
                 transfer.close();
 
             this._transfers.clear();
@@ -926,9 +926,9 @@ var Device = GObject.registerClass({
      * Plugin Functions
      */
     _onAllowedPluginsChanged(settings) {
-        let disabled = this.settings.get_strv('disabled-plugins');
-        let supported = this.settings.get_strv('supported-plugins');
-        let allowed = supported.filter(name => !disabled.includes(name));
+        const disabled = this.settings.get_strv('disabled-plugins');
+        const supported = this.settings.get_strv('supported-plugins');
+        const allowed = supported.filter(name => !disabled.includes(name));
 
         // Unload any plugins that are disabled or unsupported
         this._plugins.forEach(plugin => {
@@ -941,7 +941,7 @@ var Device = GObject.registerClass({
             this.notify('contacts');
 
         // Load allowed plugins
-        for (let name of allowed)
+        for (const name of allowed)
             this._loadPlugin(name);
     }
 
@@ -955,7 +955,7 @@ var Device = GObject.registerClass({
                 plugin = new handler.Plugin(this);
 
                 // Register packet handlers
-                for (let packetType of handler.Metadata.incomingCapabilities)
+                for (const packetType of handler.Metadata.incomingCapabilities)
                     this._handlers.set(packetType, plugin);
 
                 // Register plugin
@@ -979,9 +979,9 @@ var Device = GObject.registerClass({
     }
 
     async _loadPlugins() {
-        let disabled = this.settings.get_strv('disabled-plugins');
+        const disabled = this.settings.get_strv('disabled-plugins');
 
-        for (let name of this.settings.get_strv('supported-plugins')) {
+        for (const name of this.settings.get_strv('supported-plugins')) {
             if (!disabled.includes(name))
                 await this._loadPlugin(name);
         }
@@ -995,7 +995,7 @@ var Device = GObject.registerClass({
                 // Unregister packet handlers
                 handler = imports.service.plugins[name];
 
-                for (let type of handler.Metadata.incomingCapabilities)
+                for (const type of handler.Metadata.incomingCapabilities)
                     this._handlers.delete(type);
 
                 // Unregister plugin
@@ -1009,12 +1009,12 @@ var Device = GObject.registerClass({
     }
 
     async _unloadPlugins() {
-        for (let name of this._plugins.keys())
+        for (const name of this._plugins.keys())
             await this._unloadPlugin(name);
     }
 
     _triggerPlugins() {
-        for (let plugin of this._plugins.values()) {
+        for (const plugin of this._plugins.values()) {
             if (this.connected)
                 plugin.connected();
             else

--- a/src/service/manager.js
+++ b/src/service/manager.js
@@ -98,7 +98,7 @@ var Manager = GObject.registerClass({
         this.notify('discoverable');
 
         // FIXME: This whole thing just keeps getting uglier
-        let application = Gio.Application.get_default();
+        const application = Gio.Application.get_default();
 
         if (application === null)
             return;
@@ -109,7 +109,7 @@ var Manager = GObject.registerClass({
                 'discovery-warning'
             );
         } else {
-            let notif = new Gio.Notification();
+            const notif = new Gio.Notification();
             notif.set_title(_('Discovery Disabled'));
             notif.set_body(_('Discovery has been disabled due to the number of devices on this network.'));
             notif.set_icon(new Gio.ThemedIcon({name: 'dialog-warning'}));
@@ -154,7 +154,7 @@ var Manager = GObject.registerClass({
         this.notify('name');
 
         // Broadcast changes to the network
-        for (let backend of this.backends.values()) {
+        for (const backend of this.backends.values()) {
             backend.name = this.name;
             backend.buildIdentity();
         }
@@ -231,11 +231,11 @@ var Manager = GObject.registerClass({
     }
 
     _loadBackends() {
-        for (let name in imports.service.backends) {
+        for (const name in imports.service.backends) {
             try {
                 // Try to create the backend and track it if successful
-                let module = imports.service.backends[name];
-                let backend = new module.ChannelService({
+                const module = imports.service.backends[name];
+                const backend = new module.ChannelService({
                     id: this.id,
                     name: this.name,
                 });
@@ -261,8 +261,8 @@ var Manager = GObject.registerClass({
      */
     _loadDevices() {
         // Load cached devices
-        for (let id of this.settings.get_strv('devices')) {
-            let device = new Device.Device({body: {deviceId: id}});
+        for (const id of this.settings.get_strv('devices')) {
+            const device = new Device.Device({body: {deviceId: id}});
             this._exportDevice(device);
             this.devices.set(id, device);
         }
@@ -272,14 +272,14 @@ var Manager = GObject.registerClass({
         if (this.connection === null)
             return;
 
-        let info = {
+        const info = {
             object: null,
             interface: null,
             actions: 0,
             menu: 0,
         };
 
-        let objectPath = `${DEVICE_PATH}/${device.id.replace(/\W+/g, '_')}`;
+        const objectPath = `${DEVICE_PATH}/${device.id.replace(/\W+/g, '_')}`;
 
         // Export an object path for the device
         info.object = new Gio.DBusObjectSkeleton({
@@ -305,12 +305,12 @@ var Manager = GObject.registerClass({
         if (this.connection === null)
             return;
 
-        for (let device of this.devices.values())
+        for (const device of this.devices.values())
             this._exportDevice(device);
     }
 
     _unexportDevice(device) {
-        let info = this._exported.get(device);
+        const info = this._exported.get(device);
 
         if (info === undefined)
             return;
@@ -329,7 +329,7 @@ var Manager = GObject.registerClass({
     }
 
     _unexportDevices() {
-        for (let device of this.devices.values())
+        for (const device of this.devices.values())
             this._unexportDevice(device);
     }
 
@@ -350,7 +350,7 @@ var Manager = GObject.registerClass({
             //
             // If this is the third unpaired device to connect, we disable
             // discovery to avoid choking on networks with many devices
-            let unpaired = Array.from(this.devices.values()).filter(dev => {
+            const unpaired = Array.from(this.devices.values()).filter(dev => {
                 return !dev.paired;
             });
 
@@ -378,11 +378,11 @@ var Manager = GObject.registerClass({
      */
     _removeDevice(id) {
         // Delete all GSettings
-        let settings_path = `/org/gnome/shell/extensions/gsconnect/${id}/`;
+        const settings_path = `/org/gnome/shell/extensions/gsconnect/${id}/`;
         GLib.spawn_command_line_async(`dconf reset -f ${settings_path}`);
 
         // Delete the cache
-        let cache = GLib.build_filenamev([Config.CACHEDIR, id]);
+        const cache = GLib.build_filenamev([Config.CACHEDIR, id]);
         Gio.File.rm_rf(cache);
 
         // Forget the device
@@ -397,7 +397,7 @@ var Manager = GObject.registerClass({
      * @return {boolean} Always %true
      */
     _reconnect() {
-        for (let [id, device] of this.devices) {
+        for (const [id, device] of this.devices) {
             if (device.connected)
                 continue;
 
@@ -423,9 +423,9 @@ var Manager = GObject.registerClass({
         try {
             // If we're passed a parameter, try and find a backend for it
             if (uri !== null) {
-                let [scheme, address] = uri.split('://');
+                const [scheme, address] = uri.split('://');
 
-                let backend = this.backends.get(scheme);
+                const backend = this.backends.get(scheme);
 
                 if (backend !== undefined)
                     backend.broadcast(address);

--- a/src/service/nativeMessagingHost.js
+++ b/src/service/nativeMessagingHost.js
@@ -49,7 +49,7 @@ const NativeMessagingHost = GObject.registerClass({
             byte_order: Gio.DataStreamByteOrder.HOST_ENDIAN,
         });
 
-        let source = this._stdin.base_stream.create_source(null);
+        const source = this._stdin.base_stream.create_source(null);
         source.set_callback(this.receive.bind(this));
         source.attach(null);
 
@@ -69,8 +69,8 @@ const NativeMessagingHost = GObject.registerClass({
         }
 
         // Add currently managed devices
-        for (let object of this._manager.get_objects()) {
-            for (let iface of object.get_interfaces())
+        for (const object of this._manager.get_objects()) {
+            for (const iface of object.get_interfaces())
                 this._onInterfaceAdded(this._manager, object, iface);
         }
 
@@ -105,9 +105,9 @@ const NativeMessagingHost = GObject.registerClass({
     receive() {
         try {
             // Read the message
-            let length = this._stdin.read_int32(null);
-            let bytes = this._stdin.read_bytes(length, null).toArray();
-            let message = JSON.parse(imports.byteArray.toString(bytes));
+            const length = this._stdin.read_int32(null);
+            const bytes = this._stdin.read_bytes(length, null).toArray();
+            const message = JSON.parse(imports.byteArray.toString(bytes));
 
             // A request for a list of devices
             if (message.type === 'devices') {
@@ -116,7 +116,7 @@ const NativeMessagingHost = GObject.registerClass({
             // A request to invoke an action
             } else if (message.type === 'share') {
                 let actionName;
-                let device = this.devices[message.data.device];
+                const device = this.devices[message.data.device];
 
                 if (device) {
                     if (message.data.action === 'share')
@@ -139,7 +139,7 @@ const NativeMessagingHost = GObject.registerClass({
 
     send(message) {
         try {
-            let data = JSON.stringify(message);
+            const data = JSON.stringify(message);
             this._stdout.put_int32(data.length, null);
             this._stdout.put_string(data, null);
         } catch (e) {
@@ -153,11 +153,11 @@ const NativeMessagingHost = GObject.registerClass({
             return this.send({type: 'connected', data: false});
 
         // Collect all the devices with supported actions
-        let available = [];
+        const available = [];
 
-        for (let device of Object.values(this.devices)) {
-            let share = device.actions.get_action_enabled('shareUri');
-            let telephony = device.actions.get_action_enabled('shareSms');
+        for (const device of Object.values(this.devices)) {
+            const share = device.actions.get_action_enabled('shareUri');
+            const telephony = device.actions.get_action_enabled('shareSms');
 
             if (share || telephony) {
                 available.push({

--- a/src/service/plugin.js
+++ b/src/service/plugin.js
@@ -43,7 +43,7 @@ var Plugin = GObject.registerClass({
             this._meta = imports.service.plugins[name].Metadata;
 
         // GSettings
-        let schema = Config.GSCHEMA.lookup(this._meta.id, false);
+        const schema = Config.GSCHEMA.lookup(this._meta.id, false);
 
         if (schema !== null) {
             this.settings = new Gio.Settings({
@@ -56,10 +56,10 @@ var Plugin = GObject.registerClass({
         this._gactions = [];
 
         if (this._meta.actions) {
-            let menu = this.device.settings.get_strv('menu-actions');
+            const menu = this.device.settings.get_strv('menu-actions');
 
-            for (let name in this._meta.actions) {
-                let info = this._meta.actions[name];
+            for (const name in this._meta.actions) {
+                const info = this._meta.actions[name];
                 this._registerAction(name, menu.indexOf(name), info);
             }
         }
@@ -99,7 +99,7 @@ var Plugin = GObject.registerClass({
     _registerAction(name, menuIndex, info) {
         try {
             // Device Action
-            let action = new Gio.SimpleAction({
+            const action = new Gio.SimpleAction({
                 name: name,
                 parameter_type: info.parameter_type,
                 enabled: false,
@@ -129,11 +129,11 @@ var Plugin = GObject.registerClass({
      */
     connected() {
         // Enabled based on device capabilities, which might change
-        let incoming = this.device.settings.get_strv('incoming-capabilities');
-        let outgoing = this.device.settings.get_strv('outgoing-capabilities');
+        const incoming = this.device.settings.get_strv('incoming-capabilities');
+        const outgoing = this.device.settings.get_strv('outgoing-capabilities');
 
-        for (let action of this._gactions) {
-            let info = this._meta.actions[action.name];
+        for (const action of this._gactions) {
+            const info = this._meta.actions[action.name];
 
             if (info.incoming.every(type => outgoing.includes(type)) &&
                 info.outgoing.every(type => incoming.includes(type)))
@@ -145,7 +145,7 @@ var Plugin = GObject.registerClass({
      * Called when the device disconnects.
      */
     disconnected() {
-        for (let action of this._gactions)
+        for (const action of this._gactions)
             action.set_enabled(false);
     }
 
@@ -174,7 +174,7 @@ var Plugin = GObject.registerClass({
             this._cacheProperties = names;
 
             // Ensure the device's cache directory exists
-            let cachedir = GLib.build_filenamev([
+            const cachedir = GLib.build_filenamev([
                 Config.CACHEDIR,
                 this.device.id,
             ]);
@@ -188,8 +188,8 @@ var Plugin = GObject.registerClass({
             await new Promise((resolve, reject) => {
                 this._cacheFile.load_contents_async(null, (file, res) => {
                     try {
-                        let contents = file.load_contents_finish(res)[1];
-                        let cache = JSON.parse(ByteArray.toString(contents));
+                        const contents = file.load_contents_finish(res)[1];
+                        const cache = JSON.parse(ByteArray.toString(contents));
                         Object.assign(this, cache);
 
                         resolve();
@@ -226,7 +226,7 @@ var Plugin = GObject.registerClass({
         if (this._cancellable !== undefined)
             this._cancellable.cancel();
 
-        for (let action of this._gactions) {
+        for (const action of this._gactions) {
             this.device.removeMenuAction(`device.${action.name}`);
             this.device.remove_action(action.name);
         }
@@ -235,9 +235,9 @@ var Plugin = GObject.registerClass({
         if (this._cacheFile !== undefined) {
             try {
                 // Build the cache
-                let cache = {};
+                const cache = {};
 
-                for (let name of this._cacheProperties)
+                for (const name of this._cacheProperties)
                     cache[name] = this[name];
 
                 this._cacheFile.replace_contents(

--- a/src/service/plugins/battery.js
+++ b/src/service/plugins/battery.js
@@ -186,8 +186,8 @@ var Plugin = GObject.registerClass({
      */
     _updateEstimate() {
         let rate, time, level;
-        let newTime = Math.floor(Date.now() / 1000);
-        let newLevel = this.level;
+        const newTime = Math.floor(Date.now() / 1000);
+        const newLevel = this.level;
 
         // Load the state; ensure we have sane values for calculation
         if (this.charging)
@@ -206,9 +206,9 @@ var Plugin = GObject.registerClass({
 
         // Update the rate; use a weighted average to account for missed changes
         // NOTE: (rate = seconds/percent)
-        let ldiff = this.charging ? newLevel - level : level - newLevel;
-        let tdiff = newTime - time;
-        let newRate = tdiff / ldiff;
+        const ldiff = this.charging ? newLevel - level : level - newLevel;
+        const tdiff = newTime - time;
+        const newRate = tdiff / ldiff;
 
         if (newRate && Number.isFinite(newRate))
             rate = Math.floor((rate * 0.4) + (newRate * 0.6));
@@ -352,7 +352,7 @@ var Plugin = GObject.registerClass({
     _monitorState() {
         try {
             // Currently only true if the remote device is a desktop (rare)
-            let incoming = this.device.settings.get_strv('incoming-capabilities');
+            const incoming = this.device.settings.get_strv('incoming-capabilities');
 
             if (!incoming.includes('kdeconnect.battery'))
                 return;

--- a/src/service/plugins/contacts.js
+++ b/src/service/plugins/contacts.js
@@ -97,8 +97,8 @@ var Plugin = GObject.registerClass({
 
     _handleUids(packet) {
         try {
-            let contacts = this._store.contacts;
-            let remote_uids = packet.body.uids;
+            const contacts = this._store.contacts;
+            const remote_uids = packet.body.uids;
             let removed = false;
             delete packet.body.uids;
 
@@ -108,7 +108,7 @@ var Plugin = GObject.registerClass({
 
             // Delete any contacts that were removed on the device
             for (let i = 0, len = contacts.length; i < len; i++) {
-                let contact = contacts[i];
+                const contact = contacts[i];
 
                 if (!remote_uids.includes(contact.id)) {
                     this._store.remove(contact.id, false);
@@ -117,10 +117,10 @@ var Plugin = GObject.registerClass({
             }
 
             // Build a list of new or updated contacts
-            let uids = [];
+            const uids = [];
 
-            for (let [uid, timestamp] of Object.entries(packet.body)) {
-                let contact = this._store.get_contact(uid);
+            for (const [uid, timestamp] of Object.entries(packet.body)) {
+                const contact = this._store.get_contact(uid);
 
                 if (!contact || contact.timestamp !== timestamp)
                     uids.push(uid);
@@ -154,7 +154,7 @@ var Plugin = GObject.registerClass({
             .replace(/=(?:\r\n?|\n|$)/g, '')
             // https://tools.ietf.org/html/rfc2045#section-6.7, note 1.
             .replace(/=([a-fA-F0-9]{2})/g, ($0, $1) => {
-                let codePoint = parseInt($1, 16);
+                const codePoint = parseInt($1, 16);
                 return String.fromCharCode(codePoint);
             });
     }
@@ -169,7 +169,7 @@ var Plugin = GObject.registerClass({
      */
     _decodeUTF8(input) {
         try {
-            let output = [];
+            const output = [];
             let i = 0;
             let c1 = 0;
             let seqlen = 0;
@@ -231,7 +231,7 @@ var Plugin = GObject.registerClass({
      */
     _parseVCard21(vcard_data) {
         // vcard skeleton
-        let vcard = {
+        const vcard = {
             fn: _('Unknown Contact'),
             tel: [],
         };
@@ -241,7 +241,7 @@ var Plugin = GObject.registerClass({
         const lines = unfolded.split(/\r\n|\r|\n/);
 
         for (let i = 0, len = lines.length; i < len; i++) {
-            let line = lines[i];
+            const line = lines[i];
             let results, key, type, value;
 
             // Empty line or a property we aren't interested in
@@ -263,10 +263,10 @@ var Plugin = GObject.registerClass({
                 type = type.split(';');
 
                 // Type(s)
-                let meta = {};
+                const meta = {};
 
                 for (let i = 0, len = type.length; i < len; i++) {
-                    let res = type[i].match(VCARD_TYPED_META);
+                    const res = type[i].match(VCARD_TYPED_META);
 
                     if (res)
                         meta[res[1]] = res[2];
@@ -310,9 +310,9 @@ var Plugin = GObject.registerClass({
      */
     async _parseVCardNative(uid, vcard_data) {
         try {
-            let vcard = this._parseVCard21(vcard_data);
+            const vcard = this._parseVCard21(vcard_data);
 
-            let contact = {
+            const contact = {
                 id: uid,
                 name: vcard.fn,
                 numbers: [],
@@ -332,7 +332,7 @@ var Plugin = GObject.registerClass({
 
             // Avatar
             if (vcard.photo) {
-                let data = GLib.base64_decode(vcard.photo[0].value[0]);
+                const data = GLib.base64_decode(vcard.photo[0].value[0]);
                 contact.avatar = await this._store.storeAvatar(data);
             }
 
@@ -350,7 +350,7 @@ var Plugin = GObject.registerClass({
      */
     async _parseVCard(uid, vcard_data) {
         try {
-            let contact = {
+            const contact = {
                 id: uid,
                 name: _('Unknown Contact'),
                 numbers: [],
@@ -358,11 +358,11 @@ var Plugin = GObject.registerClass({
                 timestamp: 0,
             };
 
-            let evcard = EBookContacts.VCard.new_from_string(vcard_data);
-            let attrs = evcard.get_attributes();
+            const evcard = EBookContacts.VCard.new_from_string(vcard_data);
+            const attrs = evcard.get_attributes();
 
             for (let i = 0, len = attrs.length; i < len; i++) {
-                let attr = attrs[i];
+                const attr = attrs[i];
                 let data, number;
 
                 switch (attr.get_name().toLowerCase()) {
@@ -412,7 +412,7 @@ var Plugin = GObject.registerClass({
             delete packet.body.uids;
 
             // Parse each vCard and add the contact
-            for (let [uid, vcard] of Object.entries(packet.body)) {
+            for (const [uid, vcard] of Object.entries(packet.body)) {
                 if (EBookContacts)
                     this._parseVCard(uid, vcard);
                 else

--- a/src/service/plugins/mpris.js
+++ b/src/service/plugins/mpris.js
@@ -72,7 +72,7 @@ var Plugin = GObject.registerClass({
     disconnected() {
         super.disconnected();
 
-        for (let [identity, player] of this._players) {
+        for (const [identity, player] of this._players) {
             this._players.delete(identity);
             player.destroy();
         }
@@ -113,16 +113,16 @@ var Plugin = GObject.registerClass({
      */
     _handlePlayerList(playerList) {
         // Destroy removed players before adding new ones
-        for (let player of this._players.values()) {
+        for (const player of this._players.values()) {
             if (!playerList.includes(player.Identity)) {
                 this._players.delete(player.Identity);
                 player.destroy();
             }
         }
 
-        for (let identity of playerList) {
+        for (const identity of playerList) {
             if (!this._players.has(identity)) {
-                let player = new PlayerRemote(this.device, identity);
+                const player = new PlayerRemote(this.device, identity);
                 this._players.set(identity, player);
             }
 
@@ -144,7 +144,7 @@ var Plugin = GObject.registerClass({
      * @param {Object} packet - A `kdeconnect.mpris` packet
      */
     _handlePlayerUpdate(packet) {
-        let player = this._players.get(packet.body.player);
+        const player = this._players.get(packet.body.player);
 
         if (player === undefined)
             return;
@@ -234,14 +234,14 @@ var Plugin = GObject.registerClass({
                 await player.Seek(packet.body.Seek * 1000);
 
             if (packet.body.hasOwnProperty('SetPosition')) {
-                let offset = (packet.body.SetPosition * 1000) - player.Position;
+                const offset = (packet.body.SetPosition * 1000) - player.Position;
                 await player.Seek(offset);
             }
 
             // Information Request
             let hasResponse = false;
 
-            let response = {
+            const response = {
                 type: 'kdeconnect.mpris',
                 body: {
                     player: packet.body.player,
@@ -261,20 +261,20 @@ var Plugin = GObject.registerClass({
                     canSeek: player.CanSeek,
                 });
 
-                let metadata = player.Metadata;
+                const metadata = player.Metadata;
 
                 if (metadata.hasOwnProperty('mpris:artUrl')) {
-                    let file = Gio.File.new_for_uri(metadata['mpris:artUrl']);
+                    const file = Gio.File.new_for_uri(metadata['mpris:artUrl']);
                     response.body.albumArtUrl = file.get_uri();
                 }
 
                 if (metadata.hasOwnProperty('mpris:length')) {
-                    let trackLen = Math.floor(metadata['mpris:length'] / 1000);
+                    const trackLen = Math.floor(metadata['mpris:length'] / 1000);
                     response.body.length = trackLen;
                 }
 
                 if (metadata.hasOwnProperty('xesam:artist')) {
-                    let artists = metadata['xesam:artist'];
+                    const artists = metadata['xesam:artist'];
                     response.body.artist = artists.join(', ');
                 }
 
@@ -350,13 +350,13 @@ var Plugin = GObject.registerClass({
                 return;
 
             // Ensure the requested albumArtUrl matches the current mpris:artUrl
-            let metadata = player.Metadata;
+            const metadata = player.Metadata;
 
             if (!metadata.hasOwnProperty('mpris:artUrl'))
                 return;
 
-            let file = Gio.File.new_for_uri(metadata['mpris:artUrl']);
-            let request = Gio.File.new_for_uri(packet.body.albumArtUrl);
+            const file = Gio.File.new_for_uri(metadata['mpris:artUrl']);
+            const request = Gio.File.new_for_uri(packet.body.albumArtUrl);
 
             if (file.get_uri() !== request.get_uri())
                 throw RangeError(`invalid URI "${packet.body.albumArtUrl}"`);
@@ -364,7 +364,7 @@ var Plugin = GObject.registerClass({
             // Transfer the album art
             this._transferring.add(player);
 
-            let transfer = this.device.createTransfer();
+            const transfer = this.device.createTransfer();
 
             transfer.addFile({
                 type: 'kdeconnect.mpris',
@@ -411,7 +411,7 @@ var Plugin = GObject.registerClass({
             this._mpris = Components.release('mpris');
         }
 
-        for (let [identity, player] of this._players) {
+        for (const [identity, player] of this._players) {
             this._players.delete(identity);
             player.destroy();
         }
@@ -463,7 +463,7 @@ const PlayerRemote = GObject.registerClass({
         if (this._artUrl === state.albumArtUrl)
             return;
 
-        let file = this._getFile(state.albumArtUrl);
+        const file = this._getFile(state.albumArtUrl);
 
         if (file.query_exists(null)) {
             this._artUrl = file.get_uri();
@@ -563,7 +563,7 @@ const PlayerRemote = GObject.registerClass({
             if (this._ownerId !== 0)
                 return;
 
-            let name = [
+            const name = [
                 this.device.name,
                 this.Identity,
             ].join('').replace(/[\W]*/g, '');
@@ -600,7 +600,7 @@ const PlayerRemote = GObject.registerClass({
             file = this._getFile(packet.body.albumArtUrl);
 
             // Transfer the album art
-            let transfer = this.device.createTransfer();
+            const transfer = this.device.createTransfer();
             transfer.addFile(packet, file);
 
             await transfer.start();

--- a/src/service/plugins/notification.js
+++ b/src/service/plugins/notification.js
@@ -103,7 +103,7 @@ const SMS_APPS = [
  * @return {boolean} Whether the notification is from an SMS app
  */
 function _isSmsNotification(packet) {
-    let id = packet.body.id;
+    const id = packet.body.id;
 
     if (id.includes('sms'))
         return true;
@@ -217,7 +217,7 @@ var Plugin = GObject.registerClass({
             return;
 
         try {
-            let json = settings.get_string(key);
+            const json = settings.get_string(key);
             this._applications = JSON.parse(json);
         } catch (e) {
             debug(e, this.device.name);
@@ -230,7 +230,7 @@ var Plugin = GObject.registerClass({
 
     _onNotificationAdded(listener, notification) {
         try {
-            let notif = notification.full_unpack();
+            const notif = notification.full_unpack();
 
             // An unconfigured application
             if (notif.appName && !this._applications[notif.appName]) {
@@ -247,7 +247,7 @@ var Plugin = GObject.registerClass({
                     this._applications[notif.appName].iconName = notif.icon;
 
                 } else if (notif.icon instanceof Gio.ThemedIcon) {
-                    let iconName = notif.icon.get_names()[0];
+                    const iconName = notif.icon.get_names()[0];
                     this._applications[notif.appName].iconName = iconName;
                 }
 
@@ -325,7 +325,7 @@ var Plugin = GObject.registerClass({
         // form "type|application-id|notification-id" so we can close it with
         // the appropriate service.
         if (packet.body.hasOwnProperty('cancel')) {
-            let [, type, application, id] = ID_REGEX.exec(packet.body.cancel);
+            const [, type, application, id] = ID_REGEX.exec(packet.body.cancel);
 
             if (type === 'fdo')
                 _removeNotification(parseInt(id));
@@ -341,7 +341,7 @@ var Plugin = GObject.registerClass({
      * @param {GLib.Bytes} bytes - The icon bytes
      */
     _uploadBytesIcon(packet, bytes) {
-        let stream = Gio.MemoryInputStream.new_from_bytes(bytes);
+        const stream = Gio.MemoryInputStream.new_from_bytes(bytes);
         this._uploadIconStream(packet, stream, bytes.get_size());
     }
 
@@ -352,7 +352,7 @@ var Plugin = GObject.registerClass({
      * @param {Gio.File} file - A file object for the icon
      */
     async _uploadFileIcon(packet, file) {
-        let read = new Promise((resolve, reject) => {
+        const read = new Promise((resolve, reject) => {
             file.read_async(GLib.PRIORITY_DEFAULT, null, (file, res) => {
                 try {
                     resolve(file.read_finish(res));
@@ -362,7 +362,7 @@ var Plugin = GObject.registerClass({
             });
         });
 
-        let query = new Promise((resolve, reject) => {
+        const query = new Promise((resolve, reject) => {
             file.query_info_async(
                 'standard::size',
                 Gio.FileQueryInfoFlags.NONE,
@@ -378,7 +378,7 @@ var Plugin = GObject.registerClass({
             );
         });
 
-        let [stream, info] = await Promise.all([read, query]);
+        const [stream, info] = await Promise.all([read, query]);
 
         this._uploadIconStream(packet, stream, info.get_size());
     }
@@ -390,13 +390,13 @@ var Plugin = GObject.registerClass({
      * @param {Gio.ThemedIcon} icon - The GIcon to upload
      */
     _uploadThemedIcon(packet, icon) {
-        let theme = Gtk.IconTheme.get_default();
+        const theme = Gtk.IconTheme.get_default();
         let file = null;
 
-        for (let name of icon.names) {
+        for (const name of icon.names) {
             // NOTE: kdeconnect-android doesn't support SVGs
-            let size = Math.max.apply(null, theme.get_icon_sizes(name));
-            let info = theme.lookup_icon(name, size, Gtk.IconLookupFlags.NO_SVG);
+            const size = Math.max.apply(null, theme.get_icon_sizes(name));
+            const info = theme.lookup_icon(name, size, Gtk.IconLookupFlags.NO_SVG);
 
             // Send the first icon we find from the options
             if (info) {
@@ -420,7 +420,7 @@ var Plugin = GObject.registerClass({
      */
     async _uploadIconStream(packet, stream, size) {
         try {
-            let transfer = this.device.createTransfer();
+            const transfer = this.device.createTransfer();
             transfer.addStream(packet, stream, size);
 
             await transfer.start();
@@ -469,7 +469,7 @@ var Plugin = GObject.registerClass({
      */
     async sendNotification(notif) {
         try {
-            let icon = notif.icon || null;
+            const icon = notif.icon || null;
             delete notif.icon;
 
             await this._uploadIcon({
@@ -487,7 +487,7 @@ var Plugin = GObject.registerClass({
                 return null;
 
             // Save the file in the global cache
-            let path = GLib.build_filenamev([
+            const path = GLib.build_filenamev([
                 Config.CACHEDIR,
                 packet.body.payloadHash || `${Date.now()}`,
             ]);
@@ -495,13 +495,13 @@ var Plugin = GObject.registerClass({
             // Check if we've already downloaded this icon
             // NOTE: if we reject the transfer kdeconnect-android will resend
             //       the notification packet, which may cause problems wrt #789
-            let file = Gio.File.new_for_path(path);
+            const file = Gio.File.new_for_path(path);
 
             if (file.query_exists(null))
                 return new Gio.FileIcon({file: file});
 
             // Open the target path and create a transfer
-            let transfer = this.device.createTransfer();
+            const transfer = this.device.createTransfer();
 
             transfer.addFile(packet, file);
 
@@ -660,7 +660,7 @@ var Plugin = GObject.registerClass({
 
         // If the message has no content, open a dialog for the user to add one
         if (!message) {
-            let dialog = new NotificationUI.ReplyDialog({
+            const dialog = new NotificationUI.ReplyDialog({
                 device: this.device,
                 uuid: uuid,
                 notification: notification,

--- a/src/service/plugins/photo.js
+++ b/src/service/plugins/photo.js
@@ -83,7 +83,7 @@ var Plugin = GObject.registerClass({
             );
 
             // Fallback to ~/Pictures
-            let homeDir = GLib.get_home_dir();
+            const homeDir = GLib.get_home_dir();
 
             if (!this._receiveDir || this._receiveDir === homeDir) {
                 this._receiveDir = GLib.build_filenamev([homeDir, 'Pictures']);
@@ -106,8 +106,8 @@ var Plugin = GObject.registerClass({
      * @return {Gio.File} a file object
      */
     _getFile(filename) {
-        let dirpath = this._ensureReceiveDirectory();
-        let basepath = GLib.build_filenamev([dirpath, filename]);
+        const dirpath = this._ensureReceiveDirectory();
+        const basepath = GLib.build_filenamev([dirpath, filename]);
         let filepath = basepath;
         let copyNum = 0;
 
@@ -139,7 +139,7 @@ var Plugin = GObject.registerClass({
             // Open the photo if successful, delete on failure
             await transfer.start();
 
-            let uri = file.get_uri();
+            const uri = file.get_uri();
             Gio.AppInfo.launch_default_for_uri_async(uri, null, null, null);
         } catch (e) {
             debug(e, this.device.name);
@@ -157,9 +157,9 @@ var Plugin = GObject.registerClass({
      */
     _takePhoto(packet) {
         return new Promise((resolve, reject) => {
-            let time = GLib.DateTime.new_now_local().format('%T');
-            let path = GLib.build_filenamev([GLib.get_tmp_dir(), `${time}.jpg`]);
-            let proc = this._launcher.spawnv([
+            const time = GLib.DateTime.new_now_local().format('%T');
+            const path = GLib.build_filenamev([GLib.get_tmp_dir(), `${time}.jpg`]);
+            const proc = this._launcher.spawnv([
                 Config.FFMPEG_PATH,
                 '-f', 'video4linux2',
                 '-ss', '0:0:2',
@@ -192,7 +192,7 @@ var Plugin = GObject.registerClass({
 
         try {
             // Take a photo
-            let path = await this._takePhoto();
+            const path = await this._takePhoto();
 
             if (path.startsWith('file://'))
                 file = Gio.File.new_for_uri(path);

--- a/src/service/plugins/ping.js
+++ b/src/service/plugins/ping.js
@@ -39,7 +39,7 @@ var Plugin = GObject.registerClass({
 
     handlePacket(packet) {
         // Notification
-        let notif = {
+        const notif = {
             title: this.device.name,
             body: _('Ping'),
             icon: new Gio.ThemedIcon({name: `${this.device.icon_name}`}),
@@ -55,7 +55,7 @@ var Plugin = GObject.registerClass({
     }
 
     ping(message = '') {
-        let packet = {
+        const packet = {
             type: 'kdeconnect.ping',
             body: {},
         };

--- a/src/service/plugins/runcommand.js
+++ b/src/service/plugins/runcommand.js
@@ -123,8 +123,8 @@ var Plugin = GObject.registerClass({
      */
     _handleCommand(key) {
         try {
-            let commands = this.settings.get_value('command-list');
-            let commandList = commands.recursiveUnpack();
+            const commands = this.settings.get_value('command-list');
+            const commandList = commands.recursiveUnpack();
 
             if (!commandList.hasOwnProperty(key)) {
                 throw new Gio.IOErrorEnum({
@@ -153,16 +153,16 @@ var Plugin = GObject.registerClass({
         this._remote_commands = commandList;
         this.notify('remote-commands');
 
-        let commandEntries = Object.entries(this.remote_commands);
+        const commandEntries = Object.entries(this.remote_commands);
 
         // If there are no commands, hide the menu by disabling the action
         this.device.lookup_action('commands').enabled = (commandEntries.length > 0);
 
         // Commands Submenu
-        let submenu = new Gio.Menu();
+        const submenu = new Gio.Menu();
 
-        for (let [uuid, info] of commandEntries) {
-            let item = new Gio.MenuItem();
+        for (const [uuid, info] of commandEntries) {
+            const item = new Gio.MenuItem();
             item.set_label(info.name);
             item.set_icon(
                 new Gio.ThemedIcon({name: 'application-x-executable-symbolic'})
@@ -172,7 +172,7 @@ var Plugin = GObject.registerClass({
         }
 
         // Commands Item
-        let item = new Gio.MenuItem();
+        const item = new Gio.MenuItem();
         item.set_detailed_action('device.commands::menu');
         item.set_attribute_value(
             'hidden-when',
@@ -183,8 +183,8 @@ var Plugin = GObject.registerClass({
         item.set_submenu(submenu);
 
         // If the submenu item is already present it will be replaced
-        let menuActions = this.device.settings.get_strv('menu-actions');
-        let index = menuActions.indexOf('commands');
+        const menuActions = this.device.settings.get_strv('menu-actions');
+        const index = menuActions.indexOf('commands');
 
         if (index > -1) {
             this.device.removeMenuAction('commands');
@@ -206,7 +206,7 @@ var Plugin = GObject.registerClass({
      * Send the local command list
      */
     _sendCommandList() {
-        let commands = this.settings.get_value('command-list').recursiveUnpack();
+        const commands = this.settings.get_value('command-list').recursiveUnpack();
 
         this.device.sendPacket({
             type: 'kdeconnect.runcommand',

--- a/src/service/plugins/sftp.js
+++ b/src/service/plugins/sftp.js
@@ -75,14 +75,14 @@ var Plugin = GObject.registerClass({
 
     get gmount() {
         if (this._gmount === null && this.device.connected) {
-            let host = this.device.channel.host;
+            const host = this.device.channel.host;
 
-            let regex = new RegExp(
+            const regex = new RegExp(
                 `sftp://(${host}):(1739|17[4-5][0-9]|176[0-4])`
             );
 
-            for (let mount of this._volumeMonitor.get_mounts()) {
-                let uri = mount.get_root().get_uri();
+            for (const mount of this._volumeMonitor.get_mounts()) {
+                const uri = mount.get_root().get_uri();
 
                 if (regex.test(uri)) {
                     this._gmount = mount;
@@ -126,9 +126,9 @@ var Plugin = GObject.registerClass({
         if (this._gmount !== null || !this.device.connected)
             return;
 
-        let host = this.device.channel.host;
-        let regex = new RegExp(`sftp://(${host}):(1739|17[4-5][0-9]|176[0-4])`);
-        let uri = mount.get_root().get_uri();
+        const host = this.device.channel.host;
+        const regex = new RegExp(`sftp://(${host}):(1739|17[4-5][0-9]|176[0-4])`);
+        const uri = mount.get_root().get_uri();
 
         if (!regex.test(uri))
             return;
@@ -232,7 +232,7 @@ var Plugin = GObject.registerClass({
             await this._addPrivateKey();
 
             // Create a new mount operation
-            let op = new Gio.MountOperation({
+            const op = new Gio.MountOperation({
                 username: packet.body.user || null,
                 password: packet.body.password || null,
                 password_save: Gio.PasswordSave.NEVER,
@@ -242,9 +242,9 @@ var Plugin = GObject.registerClass({
             op.connect('ask-password', this._onAskPassword);
 
             // This is the actual call to mount the device
-            let host = this.device.channel.host;
-            let uri = `sftp://${host}:${packet.body.port}/`;
-            let file = Gio.File.new_for_uri(uri);
+            const host = this.device.channel.host;
+            const uri = `sftp://${host}:${packet.body.port}/`;
+            const file = Gio.File.new_for_uri(uri);
 
             await new Promise((resolve, reject) => {
                 file.mount_enclosing_volume(0, op, null, (file, res) => {
@@ -279,7 +279,7 @@ var Plugin = GObject.registerClass({
      * @return {Promise} A promise for the operation
      */
     _addPrivateKey() {
-        let ssh_add = this._launcher.spawnv([
+        const ssh_add = this._launcher.spawnv([
             Config.SSHADD_PATH,
             GLib.build_filenamev([Config.CONFIGDIR, 'private.pem']),
         ]);
@@ -287,7 +287,7 @@ var Plugin = GObject.registerClass({
         return new Promise((resolve, reject) => {
             ssh_add.communicate_utf8_async(null, null, (proc, res) => {
                 try {
-                    let result = proc.communicate_utf8_finish(res)[1].trim();
+                    const result = proc.communicate_utf8_finish(res)[1].trim();
 
                     if (proc.get_exit_status() !== 0)
                         debug(result, this.device.name);
@@ -309,7 +309,7 @@ var Plugin = GObject.registerClass({
     async _removeHostKey(host) {
         for (let port = 1739; port <= 1764; port++) {
             try {
-                let ssh_keygen = this._launcher.spawnv([
+                const ssh_keygen = this._launcher.spawnv([
                     Config.SSHKEYGEN_PATH,
                     '-R',
                     `[${host}]:${port}`,
@@ -337,7 +337,7 @@ var Plugin = GObject.registerClass({
         if (this._unmountSection === undefined) {
             this._unmountSection = new Gio.Menu();
 
-            let unmountItem = new Gio.MenuItem();
+            const unmountItem = new Gio.MenuItem();
             unmountItem.set_label(Metadata.actions.unmount.label);
             unmountItem.set_icon(new Gio.ThemedIcon({
                 name: Metadata.actions.unmount.icon_name,
@@ -379,7 +379,7 @@ var Plugin = GObject.registerClass({
             const dirSection = new Gio.Menu();
             const unmountSection = this._getUnmountSection();
 
-            for (let [name, uri] of Object.entries(directories))
+            for (const [name, uri] of Object.entries(directories))
                 dirSection.append(name, `device.openPath::${uri}`);
 
             // Files submenu
@@ -405,8 +405,8 @@ var Plugin = GObject.registerClass({
 
     _removeSubmenu() {
         try {
-            let index = this.device.removeMenuAction('device.mount');
-            let action = this.device.lookup_action('mount');
+            const index = this.device.removeMenuAction('device.mount');
+            const action = this.device.lookup_action('mount');
 
             if (action !== null) {
                 this.device.addMenuAction(
@@ -428,7 +428,7 @@ var Plugin = GObject.registerClass({
      */
     async _addSymlink(mount) {
         try {
-            let by_name_dir = Gio.File.new_for_path(
+            const by_name_dir = Gio.File.new_for_path(
                 `${Config.RUNTIMEDIR}/by-name/`
             );
 
@@ -447,14 +447,14 @@ var Plugin = GObject.registerClass({
             else if (safe_device_name === '..')
                 safe_device_name = '··';
 
-            let link_target = mount.get_root().get_path();
-            let link = Gio.File.new_for_path(
+            const link_target = mount.get_root().get_path();
+            const link = Gio.File.new_for_path(
                 `${by_name_dir.get_path()}/${safe_device_name}`
             );
 
             // Check for and remove any existing stale link
             try {
-                let link_stat = await new Promise((resolve, reject) => {
+                const link_stat = await new Promise((resolve, reject) => {
                     link.query_info_async(
                         'standard::symlink-target',
                         Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,

--- a/src/service/plugins/share.js
+++ b/src/service/plugins/share.js
@@ -91,7 +91,7 @@ var Plugin = GObject.registerClass({
             );
 
             // Fallback to ~/Downloads
-            let homeDir = GLib.get_home_dir();
+            const homeDir = GLib.get_home_dir();
 
             if (!receiveDir || receiveDir === homeDir)
                 receiveDir = GLib.build_filenamev([homeDir, 'Downloads']);
@@ -107,8 +107,8 @@ var Plugin = GObject.registerClass({
     }
 
     _getFile(filename) {
-        let dirpath = this._ensureReceiveDirectory();
-        let basepath = GLib.build_filenamev([dirpath, filename]);
+        const dirpath = this._ensureReceiveDirectory();
+        const basepath = GLib.build_filenamev([dirpath, filename]);
         let filepath = basepath;
         let copyNum = 0;
 
@@ -138,10 +138,10 @@ var Plugin = GObject.registerClass({
 
     async _handleFile(packet) {
         try {
-            let file = this._getFile(packet.body.filename);
+            const file = this._getFile(packet.body.filename);
 
             // Create the transfer
-            let transfer = this.device.createTransfer();
+            const transfer = this.device.createTransfer();
 
             transfer.addFile(packet, file);
 
@@ -190,7 +190,7 @@ var Plugin = GObject.registerClass({
                 iconName = 'document-save-symbolic';
 
                 if (packet.body.open) {
-                    let uri = file.get_uri();
+                    const uri = file.get_uri();
                     Gio.AppInfo.launch_default_for_uri_async(uri, null, null, null);
                 }
             } catch (e) {
@@ -220,12 +220,12 @@ var Plugin = GObject.registerClass({
     }
 
     _handleUri(packet) {
-        let uri = packet.body.url;
+        const uri = packet.body.url;
         Gio.AppInfo.launch_default_for_uri_async(uri, null, null, null);
     }
 
     _handleText(packet) {
-        let dialog = new Gtk.MessageDialog({
+        const dialog = new Gtk.MessageDialog({
             text: _('Text Shared By %s').format(this.device.name),
             secondary_text: URI.linkify(packet.body.text),
             secondary_use_markup: true,
@@ -241,7 +241,7 @@ var Plugin = GObject.registerClass({
      * Open the file chooser dialog for selecting a file or inputing a URI.
      */
     share() {
-        let dialog = new FileChooserDialog(this.device);
+        const dialog = new FileChooserDialog(this.device);
         dialog.show();
     }
 
@@ -261,7 +261,7 @@ var Plugin = GObject.registerClass({
                 file = Gio.File.new_for_path(path);
 
             // Create the transfer
-            let transfer = this.device.createTransfer();
+            const transfer = this.device.createTransfer();
 
             transfer.addFile({
                 type: 'kdeconnect.share.request',
@@ -377,8 +377,8 @@ var FileChooserDialog = GObject.registerClass({
         this.device = device;
 
         // Align checkbox with sidebar
-        let box = this.get_content_area().get_children()[0].get_children()[0];
-        let paned = box.get_children()[0];
+        const box = this.get_content_area().get_children()[0].get_children()[0];
+        const paned = box.get_children()[0];
         paned.bind_property(
             'position',
             this.extra_widget,
@@ -413,7 +413,7 @@ var FileChooserDialog = GObject.registerClass({
         this._uriButton.connect('toggled', this._onUriButtonToggled.bind(this));
 
         this.add_button(_('Cancel'), Gtk.ResponseType.CANCEL);
-        let sendButton = this.add_button(_('Send'), Gtk.ResponseType.OK);
+        const sendButton = this.add_button(_('Send'), Gtk.ResponseType.OK);
         sendButton.connect('clicked', this._sendLink.bind(this));
 
         this.get_header_bar().pack_end(this._uriButton);
@@ -422,7 +422,7 @@ var FileChooserDialog = GObject.registerClass({
 
     _onUpdatePreview(chooser) {
         try {
-            let pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(
+            const pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(
                 chooser.get_preview_filename(),
                 chooser.get_scale_factor() * 128,
                 -1
@@ -437,7 +437,7 @@ var FileChooserDialog = GObject.registerClass({
     }
 
     _onUriButtonToggled(button) {
-        let header = this.get_header_bar();
+        const header = this.get_header_bar();
 
         // Show the URL entry
         if (button.active) {
@@ -463,15 +463,15 @@ var FileChooserDialog = GObject.registerClass({
 
     vfunc_response(response_id) {
         if (response_id === Gtk.ResponseType.OK) {
-            for (let uri of this.get_uris()) {
-                let parameter = new GLib.Variant(
+            for (const uri of this.get_uris()) {
+                const parameter = new GLib.Variant(
                     '(sb)',
                     [uri, this.extra_widget.active]
                 );
                 this.device.activate_action('shareFile', parameter);
             }
         } else if (response_id === 1) {
-            let parameter = new GLib.Variant('s', this._uriEntry.text);
+            const parameter = new GLib.Variant('s', this._uriEntry.text);
             this.device.activate_action('shareUri', parameter);
         }
 

--- a/src/service/plugins/sms.js
+++ b/src/service/plugins/sms.js
@@ -203,15 +203,15 @@ var Plugin = GObject.registerClass({
      */
     _handleDigest(messages, thread_ids) {
         // Prune threads
-        for (let thread_id of Object.keys(this.threads)) {
+        for (const thread_id of Object.keys(this.threads)) {
             if (!thread_ids.includes(thread_id))
                 delete this.threads[thread_id];
         }
 
         // Request each new or newer thread
         for (let i = 0, len = messages.length; i < len; i++) {
-            let message = messages[i];
-            let cache = this.threads[message.thread_id];
+            const message = messages[i];
+            const cache = this.threads[message.thread_id];
 
             if (cache === undefined) {
                 this._requestConversation(message.thread_id);
@@ -220,7 +220,7 @@ var Plugin = GObject.registerClass({
 
             // If this message is marked read, mark the rest as read
             if (message.read === MessageStatus.READ) {
-                for (let msg of cache)
+                for (const msg of cache)
                     msg.read = MessageStatus.READ;
             }
 
@@ -260,12 +260,12 @@ var Plugin = GObject.registerClass({
         if (!thread[0].addresses || !thread[0].addresses[0])
             return;
 
-        let thread_id = thread[0].thread_id;
-        let cache = this.threads[thread_id] || [];
+        const thread_id = thread[0].thread_id;
+        const cache = this.threads[thread_id] || [];
 
         // Handle each message
         for (let i = 0, len = thread.length; i < len; i++) {
-            let message = thread[i];
+            const message = thread[i];
 
             // TODO: We only cache messages of a known MessageBox since we
             // have no reliable way to determine its direction, let alone
@@ -274,7 +274,7 @@ var Plugin = GObject.registerClass({
                 continue;
 
             // If the message exists, just update it
-            let cacheMessage = cache.find(m => m.date === message.date);
+            const cacheMessage = cache.find(m => m.date === message.date);
 
             if (cacheMessage) {
                 Object.assign(cacheMessage, message);
@@ -300,11 +300,11 @@ var Plugin = GObject.registerClass({
             if (messages.length === 0)
                 return;
 
-            let thread_ids = [];
+            const thread_ids = [];
 
             // Perform some modification of the messages
             for (let i = 0, len = messages.length; i < len; i++) {
-                let message = messages[i];
+                const message = messages[i];
 
                 // COERCION: thread_id's to strings
                 message.thread_id = `${message.thread_id}`;
@@ -427,13 +427,13 @@ var Plugin = GObject.registerClass({
     shareSms(url) {
         // Legacy Mode
         if (this.settings.get_boolean('legacy-sms')) {
-            let window = this.window;
+            const window = this.window;
             window.present();
             window.setMessage(url);
 
         // If there are active threads, show the chooser dialog
         } else if (Object.values(this.threads).length > 0) {
-            let window = new Messaging.ConversationChooser({
+            const window = new Messaging.ConversationChooser({
                 application: Gio.Application.get_default(),
                 device: this.device,
                 message: url,
@@ -466,13 +466,13 @@ var Plugin = GObject.registerClass({
             uri = new URI.SmsURI(uri);
 
             // Lookup contacts
-            let addresses = uri.recipients.map(number => {
+            const addresses = uri.recipients.map(number => {
                 return {address: number.toPhoneNumber()};
             });
-            let contacts = this.device.contacts.lookupAddresses(addresses);
+            const contacts = this.device.contacts.lookupAddresses(addresses);
 
             // Present the window and show the conversation
-            let window = this.window;
+            const window = this.window;
             window.present();
             window.setContacts(contacts);
 
@@ -485,10 +485,10 @@ var Plugin = GObject.registerClass({
     }
 
     _threadHasAddress(thread, addressObj) {
-        let number = addressObj.address.toPhoneNumber();
+        const number = addressObj.address.toPhoneNumber();
 
-        for (let taddressObj of thread[0].addresses) {
-            let tnumber = taddressObj.address.toPhoneNumber();
+        for (const taddressObj of thread[0].addresses) {
+            const tnumber = taddressObj.address.toPhoneNumber();
 
             if (number.endsWith(tnumber) || tnumber.endsWith(number))
                 return true;
@@ -504,9 +504,9 @@ var Plugin = GObject.registerClass({
      * @return {string|null} a thread ID
      */
     getThreadIdForAddresses(addresses = []) {
-        let threads = Object.values(this.threads);
+        const threads = Object.values(this.threads);
 
-        for (let thread of threads) {
+        for (const thread of threads) {
             if (addresses.length !== thread[0].addresses.length)
                 continue;
 

--- a/src/service/plugins/systemvolume.js
+++ b/src/service/plugins/systemvolume.js
@@ -84,7 +84,7 @@ var Plugin = GObject.registerClass({
     _changeSink(packet) {
         let stream;
 
-        for (let sink of this._mixer.get_sinks()) {
+        for (const sink of this._mixer.get_sinks()) {
             if (sink.name === packet.body.name) {
                 stream = sink;
                 break;
@@ -98,7 +98,7 @@ var Plugin = GObject.registerClass({
         }
 
         // Get a cache and store volume and mute states if changed
-        let cache = this._cache.get(stream) || {};
+        const cache = this._cache.get(stream) || {};
 
         if (packet.body.hasOwnProperty('muted')) {
             cache.muted = packet.body.muted;
@@ -121,7 +121,7 @@ var Plugin = GObject.registerClass({
      * @return {Object} The updated cache object
      */
     _updateCache(stream) {
-        let state = {
+        const state = {
             name: stream.name,
             description: stream.display_name,
             muted: stream.is_muted,
@@ -146,8 +146,8 @@ var Plugin = GObject.registerClass({
             return;
 
         // Check the cache
-        let stream = this._mixer.lookup_stream_id(id);
-        let cache = this._cache.get(stream) || {};
+        const stream = this._mixer.lookup_stream_id(id);
+        const cache = this._cache.get(stream) || {};
 
         // If the port has changed we have to send the whole list to update the
         // display name
@@ -159,7 +159,7 @@ var Plugin = GObject.registerClass({
         // If only volume and/or mute are set, send a single update
         if (cache.volume !== stream.volume || cache.muted !== stream.is_muted) {
             // Update the cache
-            let state = this._updateCache(stream);
+            const state = this._updateCache(stream);
 
             // Send the stream update
             this.device.sendPacket({
@@ -173,7 +173,7 @@ var Plugin = GObject.registerClass({
      * Send a list of local sinks
      */
     _sendSinkList() {
-        let sinkList = this._mixer.get_sinks().map(sink => {
+        const sinkList = this._mixer.get_sinks().map(sink => {
             return this._updateCache(sink);
         });
 

--- a/src/service/plugins/telephony.js
+++ b/src/service/plugins/telephony.js
@@ -114,7 +114,7 @@ var Plugin = GObject.registerClass({
      * @return {Gdk.Pixbuf|null} A contact photo
      */
     _getThumbnailPixbuf(data) {
-        let loader = new GdkPixbuf.PixbufLoader();
+        const loader = new GdkPixbuf.PixbufLoader();
 
         try {
             data = GLib.base64_decode(data);

--- a/src/service/ui/__init__.js
+++ b/src/service/ui/__init__.js
@@ -21,7 +21,7 @@ Gtk.Window.prototype.restoreGeometry = function (context = 'default') {
     });
 
     // Size
-    let [width, height] = this._windowState.get_value('window-size').deepUnpack();
+    const [width, height] = this._windowState.get_value('window-size').deepUnpack();
 
     if (width && height)
         this.set_default_size(width, height);
@@ -32,10 +32,10 @@ Gtk.Window.prototype.restoreGeometry = function (context = 'default') {
 };
 
 Gtk.Window.prototype.saveGeometry = function () {
-    let state = this.get_window().get_state();
+    const state = this.get_window().get_state();
 
     // Maximized State
-    let maximized = (state & Gdk.WindowState.MAXIMIZED);
+    const maximized = (state & Gdk.WindowState.MAXIMIZED);
     this._windowState.set_boolean('window-maximized', maximized);
 
     // Leave the size at the value before maximizing
@@ -43,7 +43,7 @@ Gtk.Window.prototype.saveGeometry = function () {
         return;
 
     // Size
-    let size = this.get_size();
+    const size = this.get_size();
     this._windowState.set_value('window-size', new GLib.Variant('(ii)', size));
 };
 

--- a/src/service/ui/contacts.js
+++ b/src/service/ui/contacts.js
@@ -18,7 +18,7 @@ function randomRGBA(salt = null, alpha = 1.0) {
     let red, green, blue;
 
     if (salt !== null) {
-        let hash = new GLib.Variant('s', `${salt}`).hash();
+        const hash = new GLib.Variant('s', `${salt}`).hash();
         red = ((hash & 0xFF0000) >> 16) / 255;
         green = ((hash & 0x00FF00) >> 8) / 255;
         blue = (hash & 0x0000FF) / 255;
@@ -40,11 +40,11 @@ function randomRGBA(salt = null, alpha = 1.0) {
  * @return {number} The relative luminance of the color
  */
 function relativeLuminance(rgba) {
-    let {red, green, blue} = rgba;
+    const {red, green, blue} = rgba;
 
-    let R = (red > 0.03928) ? red / 12.92 : Math.pow(((red + 0.055) / 1.055), 2.4);
-    let G = (green > 0.03928) ? green / 12.92 : Math.pow(((green + 0.055) / 1.055), 2.4);
-    let B = (blue > 0.03928) ? blue / 12.92 : Math.pow(((blue + 0.055) / 1.055), 2.4);
+    const R = (red > 0.03928) ? red / 12.92 : Math.pow(((red + 0.055) / 1.055), 2.4);
+    const G = (green > 0.03928) ? green / 12.92 : Math.pow(((green + 0.055) / 1.055), 2.4);
+    const B = (blue > 0.03928) ? blue / 12.92 : Math.pow(((blue + 0.055) / 1.055), 2.4);
 
     return 0.2126 * R + 0.7152 * G + 0.0722 * B;
 }
@@ -58,11 +58,11 @@ function relativeLuminance(rgba) {
  * @return {Gdk.RGBA} A GdkRGBA object for the foreground color
  */
 function getFgRGBA(rgba) {
-    let bgLuminance = relativeLuminance(rgba);
-    let lightContrast = (0.07275541795665634 + 0.05) / (bgLuminance + 0.05);
-    let darkContrast = (bgLuminance + 0.05) / (0.0046439628482972135 + 0.05);
+    const bgLuminance = relativeLuminance(rgba);
+    const lightContrast = (0.07275541795665634 + 0.05) / (bgLuminance + 0.05);
+    const darkContrast = (bgLuminance + 0.05) / (0.0046439628482972135 + 0.05);
 
-    let value = (darkContrast > lightContrast) ? 0.06 : 0.94;
+    const value = (darkContrast > lightContrast) ? 0.06 : 0.94;
     return new Gdk.RGBA({red: value, green: value, blue: value, alpha: 0.5});
 }
 
@@ -104,9 +104,9 @@ function getPixbufForPath(path, size, scale = 1.0) {
 }
 
 function getPixbufForIcon(name, size, scale, bgColor) {
-    let color = getFgRGBA(bgColor);
-    let theme = Gtk.IconTheme.get_default();
-    let info = theme.lookup_icon_for_scale(
+    const color = getFgRGBA(bgColor);
+    const theme = Gtk.IconTheme.get_default();
+    const info = theme.lookup_icon_for_scale(
         name,
         size,
         scale,
@@ -153,10 +153,10 @@ function getNumberTypeLabel(type) {
  * @return {string} A (possibly) better display number for the address
  */
 function getDisplayNumber(contact, address) {
-    let number = address.toPhoneNumber();
+    const number = address.toPhoneNumber();
 
-    for (let contactNumber of contact.numbers) {
-        let cnumber = contactNumber.value.toPhoneNumber();
+    for (const contactNumber of contact.numbers) {
+        const cnumber = contactNumber.value.toPhoneNumber();
 
         if (number.endsWith(cnumber) || cnumber.endsWith(number))
             return GLib.markup_escape_text(contactNumber.value, -1);
@@ -216,9 +216,9 @@ var Avatar = GObject.registerClass({
 
     _loadSurface() {
         // Get the monitor scale
-        let display = Gdk.Display.get_default();
-        let monitor = display.get_monitor_at_window(this.get_window());
-        let scale = monitor.get_scale_factor();
+        const display = Gdk.Display.get_default();
+        const monitor = display.get_monitor_at_window(this.get_window());
+        const scale = monitor.get_scale_factor();
 
         // If there's a contact with an avatar, try to load it
         if (this.contact && this.contact.avatar) {
@@ -227,7 +227,7 @@ var Avatar = GObject.registerClass({
 
             // Try loading the pixbuf
             if (!this._surface) {
-                let pixbuf = getPixbufForPath(
+                const pixbuf = getPixbufForPath(
                     this.contact.avatar,
                     this.width_request,
                     scale
@@ -258,7 +258,7 @@ var Avatar = GObject.registerClass({
             this._offset = (this.width_request - 24) / 2;
 
             // Load the fallback
-            let pixbuf = getPixbufForIcon(iconName, 24, scale, this.rgba);
+            const pixbuf = getPixbufForIcon(iconName, 24, scale, this.rgba);
 
             this._surface = Gdk.cairo_surface_create_from_pixbuf(
                 pixbuf,
@@ -273,7 +273,7 @@ var Avatar = GObject.registerClass({
             this._loadSurface();
 
         // Clip to a circle
-        let rad = this.width_request / 2;
+        const rad = this.width_request / 2;
         cr.arc(rad, rad, rad, 0, 2 * Math.PI);
         cr.clipPreserve();
 
@@ -435,7 +435,7 @@ var ContactChooser = GObject.registerClass({
             this._store.disconnect(this._contactChangedId);
 
             // Clear the contact list
-            let rows = this.list.get_children();
+            const rows = this.list.get_children();
 
             for (let i = 0, len = rows.length; i < len; i++) {
                 rows[i].destroy();
@@ -474,15 +474,15 @@ var ContactChooser = GObject.registerClass({
      * ContactStore Callbacks
      */
     _onContactAdded(store, id) {
-        let contact = this.store.get_contact(id);
+        const contact = this.store.get_contact(id);
         this._addContact(contact);
     }
 
     _onContactRemoved(store, id) {
-        let rows = this.list.get_children();
+        const rows = this.list.get_children();
 
         for (let i = 0, len = rows.length; i < len; i++) {
-            let row = rows[i];
+            const row = rows[i];
 
             if (row.contact.id === id) {
                 row.destroy();
@@ -519,7 +519,7 @@ var ContactChooser = GObject.registerClass({
 
             // ...or if we already do, then update it
             } else {
-                let address = entry.text;
+                const address = entry.text;
 
                 // Update contact object
                 dynamic.contact.name = address;
@@ -545,7 +545,7 @@ var ContactChooser = GObject.registerClass({
             return;
 
         // Emit the number
-        let address = row.number.value;
+        const address = row.number.value;
         this.emit('number-selected', address);
 
         // Reset the contact list
@@ -559,19 +559,19 @@ var ContactChooser = GObject.registerClass({
         if (row.__tmp)
             return true;
 
-        let query = row.get_parent()._entry;
+        const query = row.get_parent()._entry;
 
         // Show contact if text is substring of name
-        let queryName = query.toLocaleLowerCase();
+        const queryName = query.toLocaleLowerCase();
 
         if (row.contact.name.toLocaleLowerCase().includes(queryName))
             return true;
 
         // Show contact if text is substring of number
-        let queryNumber = query.toPhoneNumber();
+        const queryNumber = query.toPhoneNumber();
 
         if (queryNumber.length) {
-            for (let number of row.contact.numbers) {
+            for (const number of row.contact.numbers) {
                 if (number.value.toPhoneNumber().includes(queryNumber))
                     return true;
             }
@@ -596,14 +596,14 @@ var ContactChooser = GObject.registerClass({
 
     _populate() {
         // Add each contact
-        let contacts = this.store.contacts;
+        const contacts = this.store.contacts;
 
         for (let i = 0, len = contacts.length; i < len; i++)
             this._addContact(contacts[i]);
     }
 
     _addContactNumber(contact, index) {
-        let row = new AddressRow(contact, index);
+        const row = new AddressRow(contact, index);
         this.list.add(row);
 
         return row;
@@ -632,9 +632,9 @@ var ContactChooser = GObject.registerClass({
      */
     getSelected() {
         try {
-            let selected = {};
+            const selected = {};
 
-            for (let row of this.list.get_selected_rows())
+            for (const row of this.list.get_selected_rows())
                 selected[row.number.value] = row.contact;
 
             return selected;

--- a/src/service/ui/contacts.js
+++ b/src/service/ui/contacts.js
@@ -77,7 +77,7 @@ function getFgRGBA(rgba) {
  * @return {Gdk.Pixbuf} A pixbuf
  */
 function getPixbufForPath(path, size, scale = 1.0) {
-    let data, loader, pixbuf;
+    let data, loader;
 
     // Catch missing avatar files
     try {
@@ -96,7 +96,7 @@ function getPixbufForPath(path, size, scale = 1.0) {
         debug(e, path);
     }
 
-    pixbuf = loader.get_pixbuf();
+    const pixbuf = loader.get_pixbuf();
 
     // Scale to monitor
     size = Math.floor(size * scale);

--- a/src/service/ui/legacyMessaging.js
+++ b/src/service/ui/legacyMessaging.js
@@ -195,7 +195,7 @@ var Dialog = GObject.registerClass({
     }
 
     _onNumberSelected(chooser, number) {
-        let contacts = chooser.getSelected();
+        const contacts = chooser.getSelected();
 
         this.addresses = Object.keys(contacts).map(address => {
             return {address: address};

--- a/src/service/ui/messaging.js
+++ b/src/service/ui/messaging.js
@@ -90,9 +90,9 @@ const _cFormat = new Intl.DateTimeFormat('default', {
  * @return {string} A localized timestamp similar to what Android Messages uses
  */
 function getTime(time) {
-    let date = new Date(time);
-    let now = new Date();
-    let diff = now - time;
+    const date = new Date(time);
+    const now = new Date();
+    const diff = now - time;
 
     // Super recent
     if (diff < TIME_SPAN_MINUTE)
@@ -132,9 +132,9 @@ function getTime(time) {
  * @return {string} A localized timestamp similar to what Android Messages uses
  */
 function getShortTime(time) {
-    let date = new Date(time);
-    let now = new Date();
-    let diff = now - time;
+    const date = new Date(time);
+    const now = new Date();
+    const diff = now - time;
 
     if (diff < TIME_SPAN_MINUTE)
         // TRANSLATORS: Less than a minute ago
@@ -178,7 +178,7 @@ function getDetailedTime(time) {
 
 
 function setAvatarVisible(row, visible) {
-    let incoming = row.message.type === Sms.MessageBox.INBOX;
+    const incoming = row.message.type === Sms.MessageBox.INBOX;
 
     // Adjust the margins
     if (visible) {
@@ -368,14 +368,14 @@ const Conversation = GObject.registerClass({
 
         for (let i = 0, len = this.addresses.length; i < len; i++) {
             // Lookup the contact
-            let address = this.addresses[i].address;
-            let contact = this.device.contacts.query({number: address});
+            const address = this.addresses[i].address;
+            const contact = this.device.contacts.query({number: address});
 
             // Get corrected address
             let number = address.toPhoneNumber();
 
-            for (let contactNumber of contact.numbers) {
-                let cnumber = contactNumber.value.toPhoneNumber();
+            for (const contactNumber of contact.numbers) {
+                const cnumber = contactNumber.value.toPhoneNumber();
 
                 if (number.endsWith(cnumber) || cnumber.endsWith(number)) {
                     number = contactNumber.value;
@@ -431,8 +431,8 @@ const Conversation = GObject.registerClass({
     }
 
     set thread_id(thread_id) {
-        let thread = this.plugin.threads[thread_id];
-        let message = (thread) ? thread[0] : null;
+        const thread = this.plugin.threads[thread_id];
+        const message = (thread) ? thread[0] : null;
 
         if (message && this.addresses.length === 0) {
             this.addresses = message.addresses;
@@ -471,9 +471,9 @@ const Conversation = GObject.registerClass({
     }
 
     _onKeyPressEvent(entry, event) {
-        let keyval = event.get_keyval()[1];
-        let state = event.get_state()[1];
-        let mask = state & Gtk.accelerator_get_default_mod_mask();
+        const keyval = event.get_keyval()[1];
+        const state = event.get_state()[1];
+        const mask = state & Gtk.accelerator_get_default_mod_mask();
 
         if (keyval === Gdk.KEY_Return && (mask & Gdk.ModifierType.SHIFT_MASK)) {
             entry.emit('insert-at-cursor', '\n');
@@ -492,7 +492,7 @@ const Conversation = GObject.registerClass({
         this.plugin.sendMessage(this.addresses, this.entry.text);
 
         // Add a phony message in the pending box
-        let message = new Gtk.Label({
+        const message = new Gtk.Label({
             label: URI.linkify(this.entry.text),
             halign: Gtk.Align.END,
             selectable: true,
@@ -515,8 +515,8 @@ const Conversation = GObject.registerClass({
     }
 
     _onSizeAllocate(listbox, allocation) {
-        let upper = this._vadj.get_upper();
-        let pageSize = this._vadj.get_page_size();
+        const upper = this._vadj.get_upper();
+        const pageSize = this._vadj.get_page_size();
 
         // If the scrolled window hasn't been filled yet, load another message
         if (upper <= pageSize) {
@@ -543,7 +543,7 @@ const Conversation = GObject.registerClass({
      */
     _createMessageRow(message) {
         // Ensure we have a contact
-        let sender = message.addresses[0].address || 'unknown';
+        const sender = message.addresses[0].address || 'unknown';
 
         if (this.contacts[sender] === undefined) {
             this.contacts[sender] = this.device.contacts.query({
@@ -657,7 +657,7 @@ const Conversation = GObject.registerClass({
                 throw TypeError(`invalid message box ${message.type}`);
 
             // Append the message
-            let row = this._createMessageRow(message);
+            const row = this._createMessageRow(message);
             this.list.add(row);
             this.list.invalidate_headers();
 
@@ -676,7 +676,7 @@ const Conversation = GObject.registerClass({
      */
     logPrevious() {
         try {
-            let message = this.__messages.pop();
+            const message = this.__messages.pop();
 
             if (!message)
                 return;
@@ -687,7 +687,7 @@ const Conversation = GObject.registerClass({
                 throw TypeError(`invalid message box ${message.type}`);
 
             // Prepend the message
-            let row = this._createMessageRow(message);
+            const row = this._createMessageRow(message);
             this.list.prepend(row);
             this.list.invalidate_headers();
         } catch (e) {
@@ -748,7 +748,7 @@ const ConversationSummary = GObject.registerClass({
         } else {
             this.avatar.contact = null;
             nameLabel = _('Group Message');
-            let participants = [];
+            const participants = [];
             message.addresses.forEach((address) => {
                 participants.push(this.contacts[address.address].name);
             });
@@ -775,7 +775,7 @@ const ConversationSummary = GObject.registerClass({
         this.body_label.label = `<small>${bodyLabel}</small>`;
 
         // Time
-        let timeLabel = `<small>${getShortTime(message.date)}</small>`;
+        const timeLabel = `<small>${getShortTime(message.date)}</small>`;
         this.time_label.label = timeLabel;
     }
 
@@ -783,7 +783,7 @@ const ConversationSummary = GObject.registerClass({
      * Update the relative time label.
      */
     update() {
-        let timeLabel = `<small>${getShortTime(this.message.date)}</small>`;
+        const timeLabel = `<small>${getShortTime(this.message.date)}</small>`;
         this.time_label.label = timeLabel;
     }
 });
@@ -902,7 +902,7 @@ var Window = GObject.registerClass({
 
         // Create a conversation widget if there isn't one
         let conversation = this.stack.get_child_by_name(thread_id);
-        let thread = this.plugin.threads[thread_id];
+        const thread = this.plugin.threads[thread_id];
 
         if (conversation === null) {
             if (!thread) {
@@ -937,14 +937,14 @@ var Window = GObject.registerClass({
     }
 
     _setHeaderBar(addresses = []) {
-        let address = addresses[0].address;
-        let contact = this.device.contacts.query({number: address});
+        const address = addresses[0].address;
+        const contact = this.device.contacts.query({number: address});
 
         if (addresses.length === 1) {
             this.headerbar.title = contact.name;
             this.headerbar.subtitle = Contacts.getDisplayNumber(contact, address);
         } else {
-            let otherLength = addresses.length - 1;
+            const otherLength = addresses.length - 1;
 
             this.headerbar.title = contact.name;
             this.headerbar.subtitle = ngettext(
@@ -968,8 +968,8 @@ var Window = GObject.registerClass({
     }
 
     _onNumberSelected(chooser, number) {
-        let contacts = chooser.getSelected();
-        let row = this._getRowForContacts(contacts);
+        const contacts = chooser.getSelected();
+        const row = this._getRowForContacts(contacts);
 
         if (row)
             row.emit('activate');
@@ -982,10 +982,10 @@ var Window = GObject.registerClass({
      */
     _onThreadsChanged() {
         // Get the last message in each thread
-        let messages = {};
+        const messages = {};
 
-        for (let [thread_id, thread] of Object.entries(this.plugin.threads)) {
-            let message = thread[thread.length - 1];
+        for (const [thread_id, thread] of Object.entries(this.plugin.threads)) {
+            const message = thread[thread.length - 1];
 
             // Skip messages without a body (eg. MMS messages without text)
             if (message.body)
@@ -993,13 +993,13 @@ var Window = GObject.registerClass({
         }
 
         // Update existing summaries and destroy old ones
-        for (let row of this.thread_list.get_children()) {
-            let message = messages[row.thread_id];
+        for (const row of this.thread_list.get_children()) {
+            const message = messages[row.thread_id];
 
             // If it's an existing conversation, update it
             if (message) {
                 // Ensure there's a contact mapping
-                let sender = message.addresses[0].address || 'unknown';
+                const sender = message.addresses[0].address || 'unknown';
 
                 if (row.contacts[sender] === undefined) {
                     row.contacts[sender] = this.device.contacts.query({
@@ -1013,7 +1013,7 @@ var Window = GObject.registerClass({
             // Otherwise destroy it
             } else {
                 // Destroy the conversation widget
-                let conversation = this.stack.get_child_by_name(`${row.thread_id}`);
+                const conversation = this.stack.get_child_by_name(`${row.thread_id}`);
 
                 if (conversation) {
                     conversation.destroy();
@@ -1028,9 +1028,9 @@ var Window = GObject.registerClass({
         }
 
         // What's left in the dictionary is new summaries
-        for (let message of Object.values(messages)) {
-            let contacts = this.device.contacts.lookupAddresses(message.addresses);
-            let conversation = new ConversationSummary(contacts, message);
+        for (const message of Object.values(messages)) {
+            const contacts = this.device.contacts.lookupAddresses(message.addresses);
+            const conversation = new ConversationSummary(contacts, message);
             this.thread_list.add(conversation);
         }
 
@@ -1069,14 +1069,14 @@ var Window = GObject.registerClass({
      * @return {ConversationSummary|null} The thread row or %null
      */
     _getRowForContacts(contacts) {
-        let addresses = Object.keys(contacts).map(address => {
+        const addresses = Object.keys(contacts).map(address => {
             return {address: address};
         });
 
         // Try to find a thread_id
-        let thread_id = this.plugin.getThreadIdForAddresses(addresses);
+        const thread_id = this.plugin.getThreadIdForAddresses(addresses);
 
-        for (let row of this.thread_list.get_children()) {
+        for (const row of this.thread_list.get_children()) {
             if (row.message.thread_id === thread_id)
                 return row;
         }
@@ -1086,9 +1086,9 @@ var Window = GObject.registerClass({
 
     setContacts(contacts) {
         // Group the addresses
-        let addresses = [];
+        const addresses = [];
 
-        for (let address of Object.keys(contacts))
+        for (const address of Object.keys(contacts))
             addresses.push({address: address});
 
         // Try to find a thread ID for this address group
@@ -1100,7 +1100,7 @@ var Window = GObject.registerClass({
             thread_id = thread_id.toString();
 
         // Try to find a thread row for the ID
-        let row = this._getRowForContacts(contacts);
+        const row = this._getRowForContacts(contacts);
 
         if (row !== null) {
             this.thread_list.select_row(row);
@@ -1108,7 +1108,7 @@ var Window = GObject.registerClass({
         }
 
         // We're creating a new conversation
-        let conversation = new Conversation({
+        const conversation = new Conversation({
             device: this.device,
             plugin: this.plugin,
             addresses: addresses,
@@ -1133,10 +1133,10 @@ var Window = GObject.registerClass({
     }
 
     _includesAddress(addresses, addressObj) {
-        let number = addressObj.address.toPhoneNumber();
+        const number = addressObj.address.toPhoneNumber();
 
-        for (let haystackObj of addresses) {
-            let tnumber = haystackObj.address.toPhoneNumber();
+        for (const haystackObj of addresses) {
+            const tnumber = haystackObj.address.toPhoneNumber();
 
             if (number.endsWith(tnumber) || tnumber.endsWith(number))
                 return true;
@@ -1157,22 +1157,22 @@ var Window = GObject.registerClass({
             return null;
 
         // First try to find a conversation by thread_id
-        let thread_id = `${message.thread_id}`;
-        let conversation = this.stack.get_child_by_name(thread_id);
+        const thread_id = `${message.thread_id}`;
+        const conversation = this.stack.get_child_by_name(thread_id);
 
         if (conversation !== null)
             return conversation;
 
         // Try and find one by matching addresses, which is necessary if we've
         // started a thread locally and haven't set the thread_id
-        let addresses = message.addresses;
+        const addresses = message.addresses;
 
-        for (let conversation of this.stack.get_children()) {
+        for (const conversation of this.stack.get_children()) {
             if (conversation.addresses === undefined ||
                 conversation.addresses.length !== addresses.length)
                 continue;
 
-            let caddrs = conversation.addresses;
+            const caddrs = conversation.addresses;
 
             // If we find a match, set `thread-id` on the conversation and the
             // child property `name`.
@@ -1255,7 +1255,7 @@ var ConversationChooser = GObject.registerClass({
         });
         this.set_titlebar(this.headerbar);
 
-        let newButton = new Gtk.Button({
+        const newButton = new Gtk.Button({
             image: new Gtk.Image({icon_name: 'list-add-symbolic'}),
             tooltip_text: _('New Conversation'),
             always_show_image: true,
@@ -1264,7 +1264,7 @@ var ConversationChooser = GObject.registerClass({
         this.headerbar.pack_start(newButton);
 
         // Threads
-        let scrolledWindow = new Gtk.ScrolledWindow({
+        const scrolledWindow = new Gtk.ScrolledWindow({
             can_focus: false,
             hexpand: true,
             vexpand: true,
@@ -1293,7 +1293,7 @@ var ConversationChooser = GObject.registerClass({
     }
 
     _new(button) {
-        let message = this.message;
+        const message = this.message;
         this.destroy();
 
         this.plugin.sms();

--- a/src/service/ui/mousepad.js
+++ b/src/service/ui/mousepad.js
@@ -98,12 +98,12 @@ var InputDialog = GObject.registerClass({
             use_header_bar: true,
         }, params));
 
-        let headerbar = this.get_titlebar();
+        const headerbar = this.get_titlebar();
         headerbar.title = _('Keyboard');
         headerbar.subtitle = this.device.name;
 
         // Main Box
-        let content = this.get_content_area();
+        const content = this.get_content_area();
         content.border_width = 0;
 
         // TRANSLATORS: Displayed when the remote keyboard is not ready to accept input
@@ -137,8 +137,8 @@ var InputDialog = GObject.registerClass({
         if (!this.plugin.state)
             debug('ignoring remote keyboard state');
 
-        let keyvalLower = Gdk.keyval_to_lower(event.keyval);
-        let realMask = event.state & Gtk.accelerator_get_default_mod_mask();
+        const keyvalLower = Gdk.keyval_to_lower(event.keyval);
+        const realMask = event.state & Gtk.accelerator_get_default_mod_mask();
 
         this.alt_label.sensitive = !isAlt(keyvalLower) && (realMask & Gdk.ModifierType.MOD1_MASK);
         this.ctrl_label.sensitive = !isCtrl(keyvalLower) && (realMask & Gdk.ModifierType.CONTROL_MASK);
@@ -186,7 +186,7 @@ var InputDialog = GObject.registerClass({
 
         debug(`keyval: ${event.keyval}, mask: ${realMask}`);
 
-        let request = {
+        const request = {
             alt: !!(realMask & Gdk.ModifierType.MOD1_MASK),
             ctrl: !!(realMask & Gdk.ModifierType.CONTROL_MASK),
             shift: !!(realMask & Gdk.ModifierType.SHIFT_MASK),
@@ -200,7 +200,7 @@ var InputDialog = GObject.registerClass({
 
         // key
         } else {
-            let codePoint = Gdk.keyval_to_unicode(event.keyval);
+            const codePoint = Gdk.keyval_to_unicode(event.keyval);
             request.key = String.fromCodePoint(codePoint);
         }
 
@@ -234,7 +234,7 @@ var InputDialog = GObject.registerClass({
 
         debug(`insert-text: ${text} (chars ${[...text].length})`);
 
-        for (let char of [...text]) {
+        for (const char of [...text]) {
             if (!char)
                 continue;
 
@@ -267,8 +267,8 @@ var InputDialog = GObject.registerClass({
         if (!this.visible || this._keyboard)
             return;
 
-        let seat = Gdk.Display.get_default().get_default_seat();
-        let status = seat.grab(
+        const seat = Gdk.Display.get_default().get_default_seat();
+        const status = seat.grab(
             this.get_window(),
             Gdk.SeatCapabilities.KEYBOARD,
             false,

--- a/src/service/ui/notification.js
+++ b/src/service/ui/notification.js
@@ -59,7 +59,7 @@ var ReplyDialog = GObject.registerClass({
         );
 
         // Notification Data
-        let headerbar = this.get_titlebar();
+        const headerbar = this.get_titlebar();
         headerbar.title = params.notification.appName;
         headerbar.subtitle = this.device.name;
 

--- a/src/service/ui/service.js
+++ b/src/service/ui/service.js
@@ -72,7 +72,7 @@ var DeviceChooser = GObject.registerClass({
     vfunc_response(response_id) {
         if (response_id === Gtk.ResponseType.OK) {
             try {
-                let device = this.device_list.get_selected_row().device;
+                const device = this.device_list.get_selected_row().device;
                 device.activate_action(this.action_name, this.action_target);
             } catch (e) {
                 logError(e);
@@ -117,9 +117,9 @@ var DeviceChooser = GObject.registerClass({
 
     _onDevicesChanged() {
         // Collect known devices
-        let devices = {};
+        const devices = {};
 
-        for (let [id, device] of this.application.devices.entries())
+        for (const [id, device] of this.application.devices.entries())
             devices[id] = device;
 
         // Prune device rows
@@ -131,13 +131,13 @@ var DeviceChooser = GObject.registerClass({
         });
 
         // Add new devices
-        for (let device of Object.values(devices)) {
-            let action = device.lookup_action(this.action_name);
+        for (const device of Object.values(devices)) {
+            const action = device.lookup_action(this.action_name);
 
             if (action === null)
                 continue;
 
-            let row = new Gtk.ListBoxRow({
+            const row = new Gtk.ListBoxRow({
                 visible: action.enabled,
             });
             row.set_name(device.id);
@@ -150,21 +150,21 @@ var DeviceChooser = GObject.registerClass({
                 Gio.SettingsBindFlags.DEFAULT
             );
 
-            let grid = new Gtk.Grid({
+            const grid = new Gtk.Grid({
                 column_spacing: 12,
                 margin: 6,
                 visible: true,
             });
             row.add(grid);
 
-            let icon = new Gtk.Image({
+            const icon = new Gtk.Image({
                 icon_name: device.icon_name,
                 pixel_size: 32,
                 visible: true,
             });
             grid.attach(icon, 0, 0, 1, 1);
 
-            let name = new Gtk.Label({
+            const name = new Gtk.Label({
                 label: device.name,
                 halign: Gtk.Align.START,
                 hexpand: true,
@@ -233,10 +233,10 @@ var ErrorDialog = GObject.registerClass({
     }
 
     _buildUri(message, stack) {
-        let body = `\`\`\`${ISSUE_HEADER}\n${stack}\n\`\`\``;
-        let titleQuery = encodeURIComponent(message).replace('%20', '+');
-        let bodyQuery = encodeURIComponent(body).replace('%20', '+');
-        let uri = `${Config.PACKAGE_BUGREPORT}?title=${titleQuery}&body=${bodyQuery}`;
+        const body = `\`\`\`${ISSUE_HEADER}\n${stack}\n\`\`\``;
+        const titleQuery = encodeURIComponent(message).replace('%20', '+');
+        const bodyQuery = encodeURIComponent(body).replace('%20', '+');
+        const uri = `${Config.PACKAGE_BUGREPORT}?title=${titleQuery}&body=${bodyQuery}`;
 
         // Reasonable URI length limit
         if (uri.length > 2000)

--- a/src/service/utils/dbus.js
+++ b/src/service/utils/dbus.js
@@ -60,18 +60,18 @@ var Interface = GObject.registerClass({
         this._instanceMethods = {};
         this._instanceProperties = {};
 
-        let info = this.get_info();
+        const info = this.get_info();
         this.connect('handle-method-call', this._call.bind(this._instance, info));
         this.connect('handle-property-get', this._get.bind(this._instance, info));
         this.connect('handle-property-set', this._set.bind(this._instance, info));
 
         // Automatically forward known signals
-        let id = this._instance.connect('notify', this._notify.bind(this));
+        const id = this._instance.connect('notify', this._notify.bind(this));
         this._instanceHandlers.push(id);
 
-        for (let signal of info.signals) {
-            let type = `(${signal.args.map(arg => arg.signature).join('')})`;
-            let id = this._instance.connect(
+        for (const signal of info.signals) {
+            const type = `(${signal.args.map(arg => arg.signature).join('')})`;
+            const id = this._instance.connect(
                 signal.name,
                 this._emit.bind(this, signal.name, type)
             );
@@ -109,11 +109,11 @@ var Interface = GObject.registerClass({
 
         // Invoke the instance method
         try {
-            let args = parameters.unpack().map(parameter => {
+            const args = parameters.unpack().map(parameter => {
                 if (parameter.get_type_string() === 'h') {
-                    let message = invocation.get_message();
-                    let fds = message.get_unix_fd_list();
-                    let idx = parameter.deepUnpack();
+                    const message = invocation.get_message();
+                    const fds = message.get_unix_fd_list();
+                    const idx = parameter.deepUnpack();
                     return fds.get(idx);
                 } else {
                     return parameter.recursiveUnpack();
@@ -184,8 +184,8 @@ var Interface = GObject.registerClass({
     }
 
     _get(info, iface, name) {
-        let nativeValue = this[iface._nativeProp(this, name)];
-        let propertyInfo = info.lookup_property(name);
+        const nativeValue = this[iface._nativeProp(this, name)];
+        const propertyInfo = info.lookup_property(name);
 
         if (nativeValue === undefined || propertyInfo === null)
             return null;
@@ -194,14 +194,14 @@ var Interface = GObject.registerClass({
     }
 
     _set(info, iface, name, value) {
-        let nativeValue = value.recursiveUnpack();
+        const nativeValue = value.recursiveUnpack();
 
         this[iface._nativeProp(this, name)] = nativeValue;
     }
 
     _notify(obj, pspec) {
-        let name = toDBusCase(pspec.name);
-        let propertyInfo = this.get_info().lookup_property(name);
+        const name = toDBusCase(pspec.name);
+        const propertyInfo = this.get_info().lookup_property(name);
 
         if (propertyInfo === null)
             return;
@@ -218,7 +218,7 @@ var Interface = GObject.registerClass({
 
     destroy() {
         try {
-            for (let id of this._instanceHandlers)
+            for (const id of this._instanceHandlers)
                 this._instance.disconnect(id);
             this._instanceHandlers = [];
 

--- a/src/service/utils/uri.js
+++ b/src/service/utils/uri.js
@@ -82,7 +82,8 @@ const _numberRegex = new RegExp(
 function findUrls(str) {
     _urlRegexp.lastIndex = 0;
 
-    let res = [], match;
+    const res = [];
+    let match;
 
     while ((match = _urlRegexp.exec(str))) {
         const name = match[2];

--- a/src/service/utils/uri.js
+++ b/src/service/utils/uri.js
@@ -85,8 +85,8 @@ function findUrls(str) {
     let res = [], match;
 
     while ((match = _urlRegexp.exec(str))) {
-        let name = match[2];
-        let url = GLib.uri_parse_scheme(name) ? name : `http://${name}`;
+        const name = match[2];
+        const url = GLib.uri_parse_scheme(name) ? name : `http://${name}`;
         res.push({name, url, pos: match.index + match[1].length});
     }
 
@@ -103,7 +103,7 @@ function findUrls(str) {
  * @return {string} the modified text
  */
 function linkify(str, title = null) {
-    let text = GLib.markup_escape_text(str, -1);
+    const text = GLib.markup_escape_text(str, -1);
 
     _urlRegexp.lastIndex = 0;
 
@@ -124,15 +124,15 @@ function linkify(str, title = null) {
 var SmsURI = class URI {
     constructor(uri) {
         _smsRegex.lastIndex = 0;
-        let [, recipients, query] = _smsRegex.exec(uri);
+        const [, recipients, query] = _smsRegex.exec(uri);
 
         this.recipients = recipients.split(',').map(recipient => {
             _numberRegex.lastIndex = 0;
-            let [, number, params] = _numberRegex.exec(recipient);
+            const [, number, params] = _numberRegex.exec(recipient);
 
             if (params) {
-                for (let param of params.substr(1).split(';')) {
-                    let [key, value] = param.split('=');
+                for (const param of params.substr(1).split(';')) {
+                    const [key, value] = param.split('=');
 
                     // add phone-context to beginning of
                     if (key === 'phone-context' && value.startsWith('+'))
@@ -144,8 +144,8 @@ var SmsURI = class URI {
         });
 
         if (query) {
-            for (let field of query.split('&')) {
-                let [key, value] = field.split('=');
+            for (const field of query.split('&')) {
+                const [key, value] = field.split('=');
 
                 if (key === 'body') {
                     if (this.body)
@@ -158,7 +158,7 @@ var SmsURI = class URI {
     }
 
     toString() {
-        let uri = `sms:${this.recipients.join(',')}`;
+        const uri = `sms:${this.recipients.join(',')}`;
 
         return this.body ? `${uri}?body=${escape(this.body)}` : uri;
     }

--- a/src/shell/clipboard.js
+++ b/src/shell/clipboard.js
@@ -209,7 +209,7 @@ var Clipboard = GObject.registerClass({
             const mimetypes = this._selection.get_mimetypes(
                 Meta.SelectionType.SELECTION_CLIPBOARD);
 
-            let mimetype = mimetypes.find(type => TEXT_MIMETYPES.includes(type));
+            const mimetype = mimetypes.find(type => TEXT_MIMETYPES.includes(type));
 
             if (mimetype !== undefined) {
                 const stream = Gio.MemoryOutputStream.new_resizable();

--- a/src/shell/device.js
+++ b/src/shell/device.js
@@ -75,8 +75,8 @@ var Battery = GObject.registerClass({
             return;
 
         if (action_group.has_action('battery')) {
-            let value = action_group.get_action_state('battery');
-            let [charging, icon_name, level, time] = value.deepUnpack();
+            const value = action_group.get_action_state('battery');
+            const [charging, icon_name, level, time] = value.deepUnpack();
 
             this._state = {
                 charging: charging,
@@ -95,7 +95,7 @@ var Battery = GObject.registerClass({
         if (action_name !== 'battery')
             return;
 
-        let [charging, icon_name, level, time] = value.deepUnpack();
+        const [charging, icon_name, level, time] = value.deepUnpack();
 
         this._state = {
             charging: charging,
@@ -111,7 +111,7 @@ var Battery = GObject.registerClass({
         if (!this._state)
             return null;
 
-        let {charging, level, time} = this._state;
+        const {charging, level, time} = this._state;
 
         if (level === 100)
             // TRANSLATORS: When the battery level is 100%
@@ -122,9 +122,9 @@ var Battery = GObject.registerClass({
             // EXAMPLE: 42% (Estimating…)
             return _('%d%% (Estimating…)').format(level);
 
-        let total = time / 60;
-        let minutes = Math.floor(total % 60);
-        let hours = Math.floor(total / 60);
+        const total = time / 60;
+        const minutes = Math.floor(total % 60);
+        const hours = Math.floor(total / 60);
 
         if (charging) {
             // TRANSLATORS: Estimated time until battery is charged
@@ -236,7 +236,7 @@ var Indicator = GObject.registerClass({
         this.add_child(this._icon);
 
         // Menu
-        let menu = new Menu({
+        const menu = new Menu({
             device: this.device,
             menu_type: 'icon',
         });

--- a/src/shell/gmenu.js
+++ b/src/shell/gmenu.js
@@ -21,7 +21,7 @@ const Tooltip = Extension.imports.shell.tooltip;
  * @return {Object} A dictionary of the item's attributes
  */
 function getItemInfo(model, index) {
-    let info = {
+    const info = {
         target: null,
         links: [],
     };
@@ -30,7 +30,7 @@ function getItemInfo(model, index) {
     let iter = model.iterate_item_attributes(index);
 
     while (iter.next()) {
-        let name = iter.get_name();
+        const name = iter.get_name();
         let value = iter.get_value();
 
         switch (name) {
@@ -162,7 +162,7 @@ var ListBox = class ListBox extends PopupMenu.PopupMenuSection {
     }
 
     _onSubmenuOpenKey(actor, event) {
-        let item = actor._delegate;
+        const item = actor._delegate;
 
         if (item.submenu && event.get_key_symbol() === Clutter.KEY_Right) {
             this.submenu = item.submenu;
@@ -187,7 +187,7 @@ var ListBox = class ListBox extends PopupMenu.PopupMenuSection {
     }
 
     _addGMenuItem(info) {
-        let item = new PopupMenu.PopupMenuItem(info.label);
+        const item = new PopupMenu.PopupMenuItem(info.label);
         this.addMenuItem(item);
 
         if (info.action !== undefined) {
@@ -210,7 +210,7 @@ var ListBox = class ListBox extends PopupMenu.PopupMenuSection {
     }
 
     _addGMenuSection(model) {
-        let section = new ListBox({
+        const section = new ListBox({
             model: model,
             action_group: this.action_group,
         });
@@ -219,7 +219,7 @@ var ListBox = class ListBox extends PopupMenu.PopupMenuSection {
 
     _addGMenuSubmenu(model, item) {
         // Add an expander arrow to the item
-        let arrow = PopupMenu.arrowIcon(St.Side.RIGHT);
+        const arrow = PopupMenu.arrowIcon(St.Side.RIGHT);
         arrow.x_align = Clutter.ActorAlign.END;
         arrow.x_expand = true;
         item.actor.add_child(arrow);
@@ -251,14 +251,14 @@ var ListBox = class ListBox extends PopupMenu.PopupMenuSection {
         this.sub.get_children().map(child => child.destroy());
 
         for (let i = 0, len = this.model.get_n_items(); i < len; i++) {
-            let info = getItemInfo(this.model, i);
+            const info = getItemInfo(this.model, i);
             let item;
 
             // A regular item
             if (info.hasOwnProperty('label'))
                 item = this._addGMenuItem(info);
 
-            for (let link of info.links) {
+            for (const link of info.links) {
                 // Submenu
                 if (link.name === 'submenu') {
                     this._addGMenuSubmenu(link.value, item);
@@ -277,9 +277,9 @@ var ListBox = class ListBox extends PopupMenu.PopupMenuSection {
         // If this is a submenu of another item...
         if (this.submenu_for) {
             // Prepend an "<= Go Back" item, bold with a unicode arrow
-            let prev = new PopupMenu.PopupMenuItem(this.submenu_for.label.text);
+            const prev = new PopupMenu.PopupMenuItem(this.submenu_for.label.text);
             prev.label.style = 'font-weight: bold;';
-            let prevArrow = PopupMenu.arrowIcon(St.Side.LEFT);
+            const prevArrow = PopupMenu.arrowIcon(St.Side.LEFT);
             prev.replace_child(prev._ornamentLabel, prevArrow);
             this.addMenuItem(prev, 0);
 
@@ -308,8 +308,8 @@ var ListBox = class ListBox extends PopupMenu.PopupMenuSection {
 
     set submenu(submenu) {
         // Get the current allocation to hold the menu width
-        let allocation = this.actor.allocation;
-        let width = Math.max(0, allocation.x2 - allocation.x1);
+        const allocation = this.actor.allocation;
+        const width = Math.max(0, allocation.x2 - allocation.x1);
 
         // Prepare the appropriate child for tweening
         if (submenu) {
@@ -407,7 +407,7 @@ var IconButton = GObject.registerClass({
             this.child = new St.Icon({gicon: params.info.icon});
 
         // Submenu
-        for (let link of params.info.links) {
+        for (const link of params.info.links) {
             if (link.name === 'submenu') {
                 this.add_accessible_state(Atk.StateType.EXPANDABLE);
                 this.toggle_mode = true;
@@ -534,7 +534,7 @@ var IconBox = class IconBox extends PopupMenu.PopupMenuSection {
 
     set submenu(submenu) {
         if (submenu) {
-            for (let button of this.box.get_children()) {
+            for (const button of this.box.get_children()) {
                 if (button.submenu && this._submenu && button.submenu !== submenu) {
                     button.checked = false;
                     button.submenu.actor.hide();
@@ -559,16 +559,16 @@ var IconBox = class IconBox extends PopupMenu.PopupMenuSection {
         if (!actor.mapped) {
             this._submenu = null;
 
-            for (let button of this.box.get_children())
+            for (const button of this.box.get_children())
                 button.checked = false;
 
-            for (let submenu of this.sub.get_children())
+            for (const submenu of this.sub.get_children())
                 submenu.hide();
         }
     }
 
     _onActionChanged(group, name, enabled) {
-        let menuItem = this._menu_items.get(name);
+        const menuItem = this._menu_items.get(name);
 
         if (menuItem !== undefined)
             menuItem.visible = group.get_action_enabled(name);
@@ -577,8 +577,8 @@ var IconBox = class IconBox extends PopupMenu.PopupMenuSection {
     _onItemsChanged(model, position, removed, added) {
         // Remove items
         while (removed > 0) {
-            let button = this.box.get_child_at_index(position);
-            let action_name = button.action_name;
+            const button = this.box.get_child_at_index(position);
+            const action_name = button.action_name;
 
             if (button.submenu)
                 button.submenu.destroy();
@@ -591,10 +591,10 @@ var IconBox = class IconBox extends PopupMenu.PopupMenuSection {
 
         // Add items
         for (let i = 0; i < added; i++) {
-            let index = position + i;
+            const index = position + i;
 
             // Create an iconic button
-            let button = new IconButton({
+            const button = new IconButton({
                 action_group: this.action_group,
                 info: getItemInfo(model, index),
                 // NOTE: Because this doesn't derive from a PopupMenu class
@@ -624,9 +624,9 @@ var IconBox = class IconBox extends PopupMenu.PopupMenuSection {
     }
 
     _onTransitionsCompleted(actor) {
-        let menu = actor._delegate;
+        const menu = actor._delegate;
 
-        for (let button of menu.box.get_children()) {
+        for (const button of menu.box.get_children()) {
             if (button.submenu && button.submenu !== menu.submenu) {
                 button.checked = false;
                 button.submenu.actor.hide();

--- a/src/shell/keybindings.js
+++ b/src/shell/keybindings.js
@@ -34,7 +34,7 @@ var Manager = class Manager {
 
     _onAcceleratorActivated(display, action, inputDevice, timestamp) {
         try {
-            let binding = this._keybindings.get(action);
+            const binding = this._keybindings.get(action);
 
             if (binding !== undefined)
                 binding.callback();
@@ -52,12 +52,12 @@ var Manager = class Manager {
      */
     add(accelerator, callback) {
         try {
-            let action = global.display.grab_accelerator(accelerator, 0);
+            const action = global.display.grab_accelerator(accelerator, 0);
 
             if (action === Meta.KeyBindingAction.NONE)
                 throw new Error(`Failed to add keybinding: '${accelerator}'`);
 
-            let name = Meta.external_binding_name_for_action(action);
+            const name = Meta.external_binding_name_for_action(action);
             Main.wm.allowKeybinding(name, Shell.ActionMode.ALL);
             this._keybindings.set(action, {name: name, callback: callback});
 
@@ -74,7 +74,7 @@ var Manager = class Manager {
      */
     remove(action) {
         try {
-            let binding = this._keybindings.get(action);
+            const binding = this._keybindings.get(action);
             global.display.ungrab_accelerator(action);
             Main.wm.allowKeybinding(binding.name, Shell.ActionMode.NONE);
             this._keybindings.delete(action);
@@ -87,7 +87,7 @@ var Manager = class Manager {
      * Remove all keybindings
      */
     removeAll() {
-        for (let action of this._keybindings.keys())
+        for (const action of this._keybindings.keys())
             this.remove(action);
     }
 

--- a/src/shell/notification.js
+++ b/src/shell/notification.js
@@ -49,7 +49,7 @@ const NotificationBanner = GObject.registerClass({
         }
 
         // Reply Button
-        let button = new St.Button({
+        const button = new St.Button({
             style_class: 'notification-button',
             label: _('Reply'),
             x_expand: true,
@@ -78,7 +78,7 @@ const NotificationBanner = GObject.registerClass({
     _onEntryRequested(button) {
         this.focused = true;
 
-        for (let child of this._buttonBox.get_children())
+        for (const child of this._buttonBox.get_children())
             child.visible = (child === this._replyEntry);
 
         // Release the notification focus with the entry focus
@@ -106,18 +106,18 @@ const NotificationBanner = GObject.registerClass({
             return;
 
         // Copy the text, then clear the entry
-        let text = clutter_text.text;
+        const text = clutter_text.text;
         clutter_text.text = '';
 
-        let {deviceId, requestReplyId} = this.notification;
+        const {deviceId, requestReplyId} = this.notification;
 
-        let target = new GLib.Variant('(ssbv)', [
+        const target = new GLib.Variant('(ssbv)', [
             deviceId,
             'replyNotification',
             true,
             new GLib.Variant('(ssa{ss})', [requestReplyId, text, {}]),
         ]);
-        let platformData = NotificationDaemon.getPlatformData();
+        const platformData = NotificationDaemon.getPlatformData();
 
         Gio.DBus.session.call(
             APP_ID,
@@ -162,13 +162,13 @@ const Source = GObject.registerClass({
 
         notification._remoteClosed = true;
 
-        let target = new GLib.Variant('(ssbv)', [
+        const target = new GLib.Variant('(ssbv)', [
             notification.deviceId,
             'closeNotification',
             true,
             new GLib.Variant('s', notification.remoteId),
         ]);
-        let platformData = NotificationDaemon.getPlatformData();
+        const platformData = NotificationDaemon.getPlatformData();
 
         Gio.DBus.session.call(
             APP_ID,
@@ -230,8 +230,8 @@ const Source = GObject.registerClass({
             notification.requestReplyId = requestReplyId;
 
             // Bail early If @notificationParams represents an exact repeat
-            let title = notificationParams.title.unpack();
-            let body = notificationParams.body
+            const title = notificationParams.title.unpack();
+            const body = notificationParams.body
                 ? notificationParams.body.unpack()
                 : null;
 
@@ -305,7 +305,7 @@ const Source = GObject.registerClass({
  * extension is loaded, it has to be patched in place.
  */
 function patchGSConnectNotificationSource() {
-    let source = Main.notificationDaemon._gtkNotificationDaemon._sources[APP_ID];
+    const source = Main.notificationDaemon._gtkNotificationDaemon._sources[APP_ID];
 
     if (source !== undefined) {
         // Patch in the subclassed methods
@@ -315,9 +315,9 @@ function patchGSConnectNotificationSource() {
         source.createBanner = Source.prototype.createBanner;
 
         // Connect to existing notifications
-        for (let notification of Object.values(source._notifications)) {
+        for (const notification of Object.values(source._notifications)) {
 
-            let _id = notification.connect('destroy', (notification, reason) => {
+            const _id = notification.connect('destroy', (notification, reason) => {
                 source._closeGSConnectNotification(notification, reason);
                 notification.disconnect(_id);
             });
@@ -334,7 +334,7 @@ const __ensureAppSource = NotificationDaemon.GtkNotificationDaemon.prototype._en
 
 // eslint-disable-next-line func-style
 const _ensureAppSource = function (appId) {
-    let source = __ensureAppSource.call(this, appId);
+    const source = __ensureAppSource.call(this, appId);
 
     if (source._appId === APP_ID) {
         source._closeGSConnectNotification = Source.prototype._closeGSConnectNotification;
@@ -365,13 +365,13 @@ const _addNotification = NotificationDaemon.GtkNotificationDaemonAppSource.proto
 function patchGtkNotificationSources() {
     // This should diverge as little as possible from the original
     // eslint-disable-next-line func-style
-    let addNotification = function (notificationId, notificationParams, showBanner) {
+    const addNotification = function (notificationId, notificationParams, showBanner) {
         this._notificationPending = true;
 
         if (this._notifications[notificationId])
             this._notifications[notificationId].destroy(MessageTray.NotificationDestroyedReason.REPLACED);
 
-        let notification = this._createNotification(notificationParams);
+        const notification = this._createNotification(notificationParams);
         notification.connect('destroy', (notification, reason) => {
             this._withdrawGSConnectNotification(notification, reason);
             delete this._notifications[notificationId];
@@ -387,7 +387,7 @@ function patchGtkNotificationSources() {
     };
 
     // eslint-disable-next-line func-style
-    let _withdrawGSConnectNotification = function (id, notification, reason) {
+    const _withdrawGSConnectNotification = function (id, notification, reason) {
         if (reason !== MessageTray.NotificationDestroyedReason.DISMISSED)
             return;
 
@@ -398,13 +398,13 @@ function patchGtkNotificationSources() {
         notification._remoteWithdrawn = true;
 
         // Recreate the notification id as it would've been sent
-        let target = new GLib.Variant('(ssbv)', [
+        const target = new GLib.Variant('(ssbv)', [
             '*',
             'withdrawNotification',
             true,
             new GLib.Variant('s', `gtk|${this._appId}|${id}`),
         ]);
-        let platformData = NotificationDaemon.getPlatformData();
+        const platformData = NotificationDaemon.getPlatformData();
 
         Gio.DBus.session.call(
             APP_ID,

--- a/src/shell/utils.js
+++ b/src/shell/utils.js
@@ -18,7 +18,7 @@ const Config = Extension.imports.config;
 function getIcon(name) {
     if (getIcon._resource === undefined) {
         // Setup the desktop icons
-        let settings = imports.gi.St.Settings.get();
+        const settings = imports.gi.St.Settings.get();
         getIcon._desktop = new imports.gi.Gtk.IconTheme();
         getIcon._desktop.set_custom_theme(settings.gtk_icon_theme);
         settings.connect('notify::gtk-icon-theme', (settings_, key_) => {
@@ -26,8 +26,8 @@ function getIcon(name) {
         });
 
         // Preload our fallbacks
-        let iconPath = 'resource://org/gnome/Shell/Extensions/GSConnect/icons';
-        let iconNames = [
+        const iconPath = 'resource://org/gnome/Shell/Extensions/GSConnect/icons';
+        const iconNames = [
             'org.gnome.Shell.Extensions.GSConnect',
             'org.gnome.Shell.Extensions.GSConnect-symbolic',
             'computer-symbolic',
@@ -41,7 +41,7 @@ function getIcon(name) {
 
         getIcon._resource = {};
 
-        for (let iconName of iconNames) {
+        for (const iconName of iconNames) {
             getIcon._resource[iconName] = new Gio.FileIcon({
                 file: Gio.File.new_for_uri(`${iconPath}/${iconName}.svg`),
             });
@@ -70,12 +70,12 @@ function getIcon(name) {
  */
 function getResource(relativePath) {
     try {
-        let bytes = Gio.resources_lookup_data(
+        const bytes = Gio.resources_lookup_data(
             GLib.build_filenamev([Config.APP_PATH, relativePath]),
             Gio.ResourceLookupFlags.NONE
         );
 
-        let source = ByteArray.toString(bytes.toArray());
+        const source = ByteArray.toString(bytes.toArray());
 
         return source.replace('@PACKAGE_DATADIR@', Config.PACKAGE_DATADIR);
     } catch (e) {
@@ -95,7 +95,7 @@ function getResource(relativePath) {
  */
 function _installFile(dirname, basename, contents) {
     try {
-        let filename = GLib.build_filenamev([dirname, basename]);
+        const filename = GLib.build_filenamev([dirname, basename]);
         GLib.mkdir_with_parents(dirname, 0o755);
 
         return GLib.file_set_contents(filename, contents);
@@ -115,7 +115,7 @@ function _installFile(dirname, basename, contents) {
  */
 function _installResource(dirname, basename, relativePath) {
     try {
-        let contents = getResource(relativePath);
+        const contents = getResource(relativePath);
 
         return _installFile(dirname, basename, contents);
     } catch (e) {
@@ -129,35 +129,35 @@ function _installResource(dirname, basename, relativePath) {
  * Install the files necessary for the GSConnect service to run.
  */
 function installService() {
-    let confDir = GLib.get_user_config_dir();
-    let dataDir = GLib.get_user_data_dir();
-    let homeDir = GLib.get_home_dir();
+    const confDir = GLib.get_user_config_dir();
+    const dataDir = GLib.get_user_data_dir();
+    const homeDir = GLib.get_home_dir();
 
     // DBus Service
-    let dbusDir = GLib.build_filenamev([dataDir, 'dbus-1', 'services']);
-    let dbusFile = `${Config.APP_ID}.service`;
+    const dbusDir = GLib.build_filenamev([dataDir, 'dbus-1', 'services']);
+    const dbusFile = `${Config.APP_ID}.service`;
 
     // Desktop Entry
-    let appDir = GLib.build_filenamev([dataDir, 'applications']);
-    let appFile = `${Config.APP_ID}.desktop`;
-    let appPrefsFile = `${Config.APP_ID}.Preferences.desktop`;
+    const appDir = GLib.build_filenamev([dataDir, 'applications']);
+    const appFile = `${Config.APP_ID}.desktop`;
+    const appPrefsFile = `${Config.APP_ID}.Preferences.desktop`;
 
     // Application Icon
-    let iconDir = GLib.build_filenamev([dataDir, 'icons', 'hicolor', 'scalable', 'apps']);
-    let iconFull = `${Config.APP_ID}.svg`;
-    let iconSym = `${Config.APP_ID}-symbolic.svg`;
+    const iconDir = GLib.build_filenamev([dataDir, 'icons', 'hicolor', 'scalable', 'apps']);
+    const iconFull = `${Config.APP_ID}.svg`;
+    const iconSym = `${Config.APP_ID}-symbolic.svg`;
 
     // File Manager Extensions
-    let fileManagers = [
+    const fileManagers = [
         [`${dataDir}/nautilus-python/extensions`, 'nautilus-gsconnect.py'],
         [`${dataDir}/nemo-python/extensions`, 'nemo-gsconnect.py'],
     ];
 
     // WebExtension Manifests
-    let manifestFile = 'org.gnome.shell.extensions.gsconnect.json';
-    let google = getResource(`webextension/${manifestFile}.google.in`);
-    let mozilla = getResource(`webextension/${manifestFile}.mozilla.in`);
-    let manifests = [
+    const manifestFile = 'org.gnome.shell.extensions.gsconnect.json';
+    const google = getResource(`webextension/${manifestFile}.google.in`);
+    const mozilla = getResource(`webextension/${manifestFile}.mozilla.in`);
+    const manifests = [
         [`${confDir}/chromium/NativeMessagingHosts/`, google],
         [`${confDir}/google-chrome/NativeMessagingHosts/`, google],
         [`${confDir}/google-chrome-beta/NativeMessagingHosts/`, google],
@@ -182,10 +182,10 @@ function installService() {
         _installResource(iconDir, iconSym, `icons/${iconSym}`);
 
         // File Manager Extensions
-        let target = `${Config.PACKAGE_DATADIR}/nautilus-gsconnect.py`;
+        const target = `${Config.PACKAGE_DATADIR}/nautilus-gsconnect.py`;
 
-        for (let [dir, name] of fileManagers) {
-            let script = Gio.File.new_for_path(GLib.build_filenamev([dir, name]));
+        for (const [dir, name] of fileManagers) {
+            const script = Gio.File.new_for_path(GLib.build_filenamev([dir, name]));
 
             if (!script.query_exists(null)) {
                 GLib.mkdir_with_parents(dir, 0o755);
@@ -194,7 +194,7 @@ function installService() {
         }
 
         // WebExtension Manifests
-        for (let [dirname, contents] of manifests)
+        for (const [dirname, contents] of manifests)
             _installFile(dirname, manifestFile, contents);
 
     // Otherwise, if running as a system extension, ensure anything previously
@@ -206,10 +206,10 @@ function installService() {
         GLib.unlink(GLib.build_filenamev([iconDir, iconFull]));
         GLib.unlink(GLib.build_filenamev([iconDir, iconSym]));
 
-        for (let [dir, name] of fileManagers)
+        for (const [dir, name] of fileManagers)
             GLib.unlink(GLib.build_filenamev([dir, name]));
 
-        for (let manifest of manifests)
+        for (const manifest of manifests)
             GLib.unlink(GLib.build_filenamev([manifest[0], manifestFile]));
     }
 }

--- a/src/utils/remote.js
+++ b/src/utils/remote.js
@@ -116,7 +116,7 @@ var Device = GObject.registerClass({
 
     vfunc_g_properties_changed(changed, invalidated) {
         try {
-            for (let name in changed.deepUnpack())
+            for (const name in changed.deepUnpack())
                 this.notify(_PROPERTIES[name]);
         } catch (e) {
             logError(e);
@@ -309,7 +309,7 @@ var Service = GObject.registerClass({
                 return;
 
             // Create a proxy
-            let device = new Device(this, object_path);
+            const device = new Device(this, object_path);
             await device.start();
 
             // Hold the proxy and emit ::device-added
@@ -333,7 +333,7 @@ var Service = GObject.registerClass({
                 return;
 
             // Get the proxy
-            let device = this._devices.get(object_path);
+            const device = this._devices.get(object_path);
 
             if (device === undefined)
                 return;
@@ -350,7 +350,7 @@ var Service = GObject.registerClass({
     }
 
     async _addDevices() {
-        let objects = await new Promise((resolve, reject) => {
+        const objects = await new Promise((resolve, reject) => {
             this.call(
                 'GetManagedObjects',
                 null,
@@ -359,7 +359,7 @@ var Service = GObject.registerClass({
                 null,
                 (proxy, res) => {
                     try {
-                        let variant = proxy.call_finish(res);
+                        const variant = proxy.call_finish(res);
                         resolve(variant.deepUnpack()[0]);
                     } catch (e) {
                         Gio.DBusError.strip_remote_error(e);
@@ -369,12 +369,12 @@ var Service = GObject.registerClass({
             );
         });
 
-        for (let [object_path, object] of Object.entries(objects))
+        for (const [object_path, object] of Object.entries(objects))
             await this._onInterfacesAdded(object_path, object);
     }
 
     _clearDevices() {
-        for (let [object_path, device] of this._devices) {
+        for (const [object_path, device] of this._devices) {
             this._devices.delete(object_path);
             this.emit('device-removed', device);
             device.destroy();
@@ -477,12 +477,12 @@ var Service = GObject.registerClass({
 
     activate_action(name, parameter = null) {
         try {
-            let paramArray = [];
+            const paramArray = [];
 
             if (parameter instanceof GLib.Variant)
                 paramArray[0] = parameter;
 
-            let connection = this.g_connection || Gio.DBus.session;
+            const connection = this.g_connection || Gio.DBus.session;
 
             connection.call(
                 SERVICE_NAME,

--- a/webextension/gettext.js
+++ b/webextension/gettext.js
@@ -66,7 +66,8 @@ template = JSON.load(template);
 
 //
 
-let info, iter = podir.enumerate_children('standard::name', 0, null);
+let info;
+const iter = podir.enumerate_children('standard::name', 0, null);
 
 while ((info = iter.next_file(null))) {
     const [lang, ext] = info.get_name().split('.');

--- a/webextension/gettext.js
+++ b/webextension/gettext.js
@@ -43,7 +43,7 @@ _('Send SMS');
 //
 JSON.load = function (gfile) {
     try {
-        let data = gfile.load_contents(null)[1];
+        const data = gfile.load_contents(null)[1];
 
         if (data instanceof Uint8Array)
             return JSON.parse(ByteArray.toString(data));
@@ -56,9 +56,9 @@ JSON.load = function (gfile) {
 };
 
 // Find the cwd, locale dir and po dir
-let cwd = Gio.File.new_for_path('.');
-let localedir = cwd.get_child('_locales');
-let podir = cwd.get_parent().get_child('po');
+const cwd = Gio.File.new_for_path('.');
+const localedir = cwd.get_child('_locales');
+const podir = cwd.get_parent().get_child('po');
 
 // Load the english translation as a template
 let template = localedir.get_child('en').get_child('messages.json');
@@ -69,7 +69,7 @@ template = JSON.load(template);
 let info, iter = podir.enumerate_children('standard::name', 0, null);
 
 while ((info = iter.next_file(null))) {
-    let [lang, ext] = info.get_name().split('.');
+    const [lang, ext] = info.get_name().split('.');
 
     // Only process PO files
     if (ext !== 'po')
@@ -87,8 +87,8 @@ while ((info = iter.next_file(null))) {
     print(`Processing ${lang} as ${langCode}`);
 
     // Make a new dir and file
-    let jsondir = localedir.get_child(langCode);
-    let jsonfile = jsondir.get_child('messages.json');
+    const jsondir = localedir.get_child(langCode);
+    const jsonfile = jsondir.get_child('messages.json');
     GLib.mkdir_with_parents(jsondir.get_path(), 448);
 
     // If the translation exists, update the template with its messages
@@ -102,7 +102,7 @@ while ((info = iter.next_file(null))) {
     let po = iter.get_child(info).load_contents(null)[1];
     po = ByteArray.toString(po);
 
-    for (let line of po.split('\n')) {
+    for (const line of po.split('\n')) {
         // If we have a msgid, we're expecting a msgstr
         if (msgid) {
             if (MSGSTR_REGEX.test(line))

--- a/webextension/js/background.js
+++ b/webextension/js/background.js
@@ -117,7 +117,7 @@ async function forwardPortMessage(message) {
  */
 async function onContextItem(info, tab) {
     try {
-        let [id, action] = info.menuItemId.split(':');
+        const [id, action] = info.menuItemId.split(':');
 
         await postMessage({
             type: 'share',
@@ -155,7 +155,7 @@ async function createContextMenu(tab) {
                 contexts: _CONTEXTS,
             });
 
-            for (let device of State.devices) {
+            for (const device of State.devices) {
                 if (device.share && device.telephony) {
                     await browser.contextMenus.create({
                         id: device.id,
@@ -204,7 +204,7 @@ async function createContextMenu(tab) {
 
         // One device; we'll create a top level menu
         } else {
-            let device = State.devices[0];
+            const device = State.devices[0];
 
             if (device.share && device.telephony) {
                 await browser.contextMenus.create({
@@ -284,7 +284,7 @@ async function onPortMessage(message) {
         forwardPortMessage(message);
 
         //
-        let tabs = await browser.tabs.query({
+        const tabs = await browser.tabs.query({
             active: true,
             currentWindow: true,
         });
@@ -326,7 +326,7 @@ async function onDisconnect(port) {
 
         // Log disconnection
         if (browser.runtime.lastError) {
-            let message = browser.runtime.lastError.message;
+            const message = browser.runtime.lastError.message;
             console.warn(`Disconnected: ${message}`);
         }
 

--- a/webextension/js/popup.js
+++ b/webextension/js/popup.js
@@ -54,21 +54,21 @@ async function sendUrl(device, action, url) {
  * @return {HTMLElement} - A <div> element with icon, name and actions
  */
 function getDeviceElement(device) {
-    let deviceElement = document.createElement('div');
+    const deviceElement = document.createElement('div');
     deviceElement.className = 'device';
 
-    let deviceIcon = document.createElement('img');
+    const deviceIcon = document.createElement('img');
     deviceIcon.className = 'device-icon';
     deviceIcon.src = `images/${device.type}.svg`;
     deviceElement.appendChild(deviceIcon);
 
-    let deviceName = document.createElement('span');
+    const deviceName = document.createElement('span');
     deviceName.className = 'device-name';
     deviceName.textContent = device.name;
     deviceElement.appendChild(deviceName);
 
     if (device.share) {
-        let shareButton = document.createElement('img');
+        const shareButton = document.createElement('img');
         shareButton.className = 'plugin-button';
         shareButton.src = 'images/open-in-browser.svg';
         shareButton.title = browser.i18n.getMessage('shareMessage');
@@ -80,7 +80,7 @@ function getDeviceElement(device) {
     }
 
     if (device.telephony) {
-        let telephonyButton = document.createElement('img');
+        const telephonyButton = document.createElement('img');
         telephonyButton.className = 'plugin-button';
         telephonyButton.src = 'images/message.svg';
         telephonyButton.title = browser.i18n.getMessage('smsMessage');
@@ -99,14 +99,14 @@ function getDeviceElement(device) {
  * Populate the browserAction popup
  */
 function setPopup() {
-    let devNode = document.getElementById('popup');
+    const devNode = document.getElementById('popup');
 
     while (devNode.hasChildNodes())
         devNode.removeChild(devNode.lastChild);
 
     if (CONNECTED && DEVICES.length) {
-        for (let device of DEVICES) {
-            let deviceElement = getDeviceElement(device);
+        for (const device of DEVICES) {
+            const deviceElement = getDeviceElement(device);
             devNode.appendChild(deviceElement);
         }
 
@@ -114,7 +114,7 @@ function setPopup() {
     }
 
     // Disconnected or no devices
-    let message = document.createElement('span');
+    const message = document.createElement('span');
     message.className = 'popup-menu-message';
     devNode.appendChild(message);
 
@@ -159,7 +159,7 @@ function onPortMessage(message, sender) {
  */
 async function onPopup() {
     try {
-        let tabs = await browser.tabs.query({
+        const tabs = await browser.tabs.query({
             active: true,
             currentWindow: true,
         });


### PR DESCRIPTION
Gjs style guidelines state that `const` should be preferred but it was missing from `eslint`.

https://gjs.guide/guides/gjs/style-guide.html#const-vs-let

I realized in retrospect my previous PR broke this rule so figured I'd push this your way in case you want it.