### PR TITLE
More verbose logging when `ssh-keygen -R` fails

### DIFF
--- a/src/service/plugins/sftp.js
+++ b/src/service/plugins/sftp.js
@@ -325,7 +325,7 @@ var Plugin = GObject.registerClass({
                     });
                 });
             } catch (e) {
-                debug(e, this.device.name);
+                logError(e, this.device.name + ': `' + argv.join(' ') + '`');
             }
         }
     }

--- a/src/service/plugins/sftp.js
+++ b/src/service/plugins/sftp.js
@@ -308,12 +308,14 @@ var Plugin = GObject.registerClass({
      */
     async _removeHostKey(host) {
         for (let port = 1739; port <= 1764; port++) {
+            let argv;
             try {
-                const ssh_keygen = this._launcher.spawnv([
+                argv = [
                     Config.SSHKEYGEN_PATH,
                     '-R',
                     `[${host}]:${port}`,
-                ]);
+                ];
+                const ssh_keygen = this._launcher.spawnv(argv);
 
                 await new Promise((resolve, reject) => {
                     ssh_keygen.wait_check_async(null, (proc, res) => {


### PR DESCRIPTION
This can happen if, e.g., `~/.ssh/known_hosts` contains any line that is not recognised as valid by the current version of OpenSSH.