### PR TITLE
Fix contacts not appearing in Messaging window

### DIFF
--- a/src/service/ui/contacts.js
+++ b/src/service/ui/contacts.js
@@ -300,15 +300,6 @@ const AddressRow = GObject.registerClass({
     GTypeName: 'GSConnectContactsAddressRow',
     Template: 'resource:///org/gnome/Shell/Extensions/GSConnect/ui/contacts-address-row.ui',
     Children: ['avatar', 'name-label', 'address-label', 'type-label'],
-    Properties: {
-        'avatar': GObject.ParamSpec.string(
-            'avatar',
-            'Avatar',
-            'Contact avatar',
-            GObject.ParamFlags.READABLE,
-            null
-        ),
-    },
 }, class AddressRow extends Gtk.ListBoxRow {
 
     _init(contact, index = 0) {


### PR DESCRIPTION
I'm not used at all to javascript, but testing the latest release of gsconnect I had to apply this patch for the contacts to show up. (it errored with missing getter for read-only property avatar)