### PR TITLE
[DRAFT] Support manifest v3 in chrome extension

### DIFF
--- a/webextension/js/background.js
+++ b/webextension/js/background.js
@@ -49,6 +49,7 @@ function logError(error) {
         console.error(error.message);
 }
 
+// browser.action.onClicked.addListener(onContextItem);
 
 /**
  * Callback for activation of the extension toolbar icon
@@ -59,11 +60,12 @@ function toggleAction(tab = null) {
     try {
         // Disable on "about:" pages
         if (_ABOUT.test(tab.url))
-            browser.browserAction.disable(tab.id);
-        else
-            browser.browserAction.enable(tab.id);
+            browser.action.disable(tab.id);
+        else {
+            browser.action.enable(tab.id);
+        }
     } catch {
-        browser.browserAction.disable();
+        browser.action.disable();
     }
 }
 
@@ -90,7 +92,7 @@ async function postMessage(message) {
 
 
 /**
- * Forward a message from the browserAction popup to the NMH
+ * Forward a message from the action popup to the NMH
  *
  * @param {object} message - A message from the NMH to forward
  * @param {*} sender - A message from the NMH to forward
@@ -106,7 +108,7 @@ async function onPopupMessage(message, sender) {
 
 
 /**
- * Forward a message from the NMH to the browserAction popup
+ * Forward a message from the NMH to the action popup
  *
  * @param {object} message - A message from the NMH to forward
  */
@@ -177,7 +179,7 @@ async function createContextMenu(tab) {
                         title: browser.i18n.getMessage('shareMessage'),
                         parentId: device.id,
                         contexts: _CONTEXTS,
-                        onclick: onContextItem,
+                        // onclick: onContextItem,
                     });
 
                     await browser.contextMenus.create({
@@ -185,7 +187,7 @@ async function createContextMenu(tab) {
                         title: browser.i18n.getMessage('smsMessage'),
                         parentId: device.id,
                         contexts: _CONTEXTS,
-                        onclick: onContextItem,
+                        // onclick: onContextItem,
                     });
                 } else {
                     let pluginAction, pluginName;
@@ -206,7 +208,7 @@ async function createContextMenu(tab) {
                         ),
                         parentId: 'contextMenuMultipleDevices',
                         contexts: _CONTEXTS,
-                        onclick: onContextItem,
+                        // onclick: onContextItem,
                     });
                 }
             }
@@ -227,7 +229,7 @@ async function createContextMenu(tab) {
                     title: browser.i18n.getMessage('shareMessage'),
                     parentId: device.id,
                     contexts: _CONTEXTS,
-                    onclick: onContextItem,
+                    // onclick: onContextItem,
                 });
 
                 await browser.contextMenus.create({
@@ -235,7 +237,7 @@ async function createContextMenu(tab) {
                     title: browser.i18n.getMessage('smsMessage'),
                     parentId: device.id,
                     contexts: _CONTEXTS,
-                    onclick: onContextItem,
+                    // onclick: onContextItem,
                 });
             } else {
                 let pluginAction, pluginName;
@@ -255,7 +257,7 @@ async function createContextMenu(tab) {
                         [device.name, pluginName]
                     ),
                     contexts: _CONTEXTS,
-                    onclick: onContextItem,
+                    // onclick: onContextItem,
                 });
             }
         }
@@ -293,10 +295,10 @@ async function onPortMessage(message) {
         forwardPortMessage(message);
 
         //
-        const tabs = await browser.tabs.query({
-            active: true,
+        const tabs = (await chrome.tabs.query({
+            // active: true,
             currentWindow: true,
-        });
+        })).filter(tab => tab.active);
 
         createContextMenu(tabs[0]);
     } catch (e) {
@@ -312,8 +314,8 @@ async function onDisconnect() {
     try {
         State.connected = false;
         State.port = null;
-        browser.browserAction.setBadgeText({text: '\u26D4'});
-        browser.browserAction.setBadgeBackgroundColor({color: [198, 40, 40, 255]});
+        browser.action.setBadgeText({text: '\u26D4'});
+        browser.action.setBadgeBackgroundColor({color: [198, 40, 40, 255]});
         forwardPortMessage({type: 'connected', data: false});
 
         // Clear context menu
@@ -321,13 +323,13 @@ async function onDisconnect() {
 
         // Disconnected, cancel back-off reset
         if (typeof reconnectResetTimer === 'number') {
-            window.clearTimeout(reconnectResetTimer);
+            clearTimeout(reconnectResetTimer);
             reconnectResetTimer = null;
         }
 
-        // Don't queue more than one reconnect
+        // // Don't queue more than one reconnect
         if (typeof reconnectTimer === 'number') {
-            window.clearTimeout(reconnectTimer);
+            clearTimeout(reconnectTimer);
             reconnectTimer = null;
         }
 
@@ -338,7 +340,7 @@ async function onDisconnect() {
         }
 
         // Exponential back-off on reconnect
-        reconnectTimer = window.setTimeout(connect, reconnectDelay);
+        reconnectTimer = setTimeout(connect, reconnectDelay);
         reconnectDelay *= 2;
     } catch (e) {
         logError(e);
@@ -354,11 +356,11 @@ async function connect() {
         State.port = browser.runtime.connectNative('org.gnome.shell.extensions.gsconnect');
 
         // Clear the badge and tell the popup we're disconnected
-        browser.browserAction.setBadgeText({text: ''});
-        browser.browserAction.setBadgeBackgroundColor({color: [0, 0, 0, 0]});
+        browser.action.setBadgeText({text: ''});
+        browser.action.setBadgeBackgroundColor({color: [0, 0, 0, 0]});
 
         // Reset the back-off delay if we stay connected
-        reconnectResetTimer = window.setTimeout(() => {
+        reconnectResetTimer = setTimeout(() => {
             reconnectDelay = 100;
         }, reconnectDelay * 0.9);
 
@@ -372,10 +374,10 @@ async function connect() {
 }
 
 
-// Forward messages from the browserAction popup
+// Forward messages from the action popup
 browser.runtime.onMessage.addListener(onPopupMessage);
 
-// Keep browserAction up to date
+// Keep action up to date
 browser.tabs.onActivated.addListener((info) => {
     browser.tabs.get(info.tabId).then(toggleAction);
 });
@@ -397,7 +399,7 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 
 
 /**
- * Startup: set initial state of the browserAction and try to connect
+ * Startup: set initial state of the action and try to connect
  */
 toggleAction();
 connect();

--- a/webextension/js/popup.js
+++ b/webextension/js/popup.js
@@ -82,7 +82,7 @@ function getDeviceElement(device) {
         shareButton.title = browser.i18n.getMessage('shareMessage');
         shareButton.addEventListener(
             'click',
-            () => sendUrl(device.id, 'share', URL)
+            () => sendUrl(device.id, 'share', TARGET_URL)
         );
         deviceElement.appendChild(shareButton);
     }
@@ -94,7 +94,7 @@ function getDeviceElement(device) {
         telephonyButton.title = browser.i18n.getMessage('smsMessage');
         telephonyButton.addEventListener(
             'click',
-            () => sendUrl(device.id, 'telephony', URL)
+            () => sendUrl(device.id, 'telephony', TARGET_URL)
         );
         deviceElement.appendChild(telephonyButton);
     }
@@ -146,7 +146,7 @@ function onPortMessage(message, sender) {
     try {
         // console.log(`WebExtension-popup RECV: ${JSON.stringify(message)}`);
 
-        if (sender.url.includes('/background.html')) {
+        // if (sender.url.includes('/background.html')) {
             if (message.type === 'connected') {
                 CONNECTED = message.data;
             } else if (message.type === 'devices') {
@@ -155,7 +155,7 @@ function onPortMessage(message, sender) {
             }
 
             setPopup();
-        }
+        // }
     } catch (e) {
         logError(e);
     }
@@ -167,10 +167,10 @@ function onPortMessage(message, sender) {
  */
 async function onPopup() {
     try {
-        const tabs = await browser.tabs.query({
-            active: true,
+        const tabs = (await browser.tabs.query({
+            // active: true,
             currentWindow: true,
-        });
+        })).filter(tab => tab.active);
 
         if (tabs.length)
             TARGET_URL = tabs[0].url;

--- a/webextension/js/webworker.js
+++ b/webextension/js/webworker.js
@@ -1,0 +1,4 @@
+self.importScripts(
+    "browser-polyfill.min.js",
+    "background.js"
+)

--- a/webextension/manifest.chrome.json
+++ b/webextension/manifest.chrome.json
@@ -1,11 +1,11 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "version": "8",
   "homepage_url": "https://github.com/GSConnect/gnome-shell-extension-gsconnect/wiki",
   "default_locale": "en",
-  "browser_action": {
+  "action": {
     "default_title": "__MSG_extensionName__",
     "default_popup": "popup.html",
     "default_icon": {
@@ -20,12 +20,15 @@
     }
   },
   "background": {
-    "page": "background.html"
+    "service_worker": "js/webworker.js"
   },
   "permissions": [
     "nativeMessaging",
     "tabs",
     "contextMenus"
+  ],
+  "host_permissions": [
+    "*://*/*"
   ],
   "icons": {
     "256": "images/gsconnect-256.png",


### PR DESCRIPTION
This is a very much not cleaned up hack job of "look at error message", "comment something out", "do minimal change", "rinse and repeat" of an effort, but it does seem to work on Chrome. I have had a half a mind of sticking it to the man and never updating to manifest-v3 and half a mind of it'd be great if they actually did disable the chrome extension so I'd stop getting those obnoxious "we buy chrome extensions" emails, but here we are all the same.

I've never done any webextensions before, so I'd especially appreciate a review focusing on "does this cause actual havoc / security vulnerabilities etc". I didn't test at all on Firefox, so I don't know what if anything should be done about that, or perhaps hope that we never have to update the Firefox extension.