### PR TITLE
Keyboard shortcuts without grabbing

### DIFF
--- a/data/ui/preferences-shortcut-editor.ui
+++ b/data/ui/preferences-shortcut-editor.ui
@@ -111,17 +111,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
                     <property name="top_attach">0</property>
                   </packing>
                 </child>
-                <child>
-                  <object class="GtkLabel" id="conflict-label">
-                    <property name="can_focus">False</property>
-                    <property name="halign">center</property>
-                    <property name="hexpand">True</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">1</property>
-                  </packing>
-                </child>
               </object>
               <packing>
                 <property name="name">confirm</property>

--- a/data/ui/preferences-shortcut-editor.ui
+++ b/data/ui/preferences-shortcut-editor.ui
@@ -52,6 +52,20 @@ SPDX-License-Identifier: GPL-2.0-or-later
           </packing>
         </child>
         <child>
+          <object class="GtkLabel">
+            <property name="can_focus">False</property>
+            <property name="halign">center</property>
+            <property name="hexpand">True</property>
+            <property name="label" translatable="yes">Note that you have to first disable any conflicting shortucts in GNOME Settings.</property>
+            <property name="visible">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkStack" id="stack">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
@@ -121,11 +135,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>
     </child>
   </template>
 </interface>
-

--- a/po/org.gnome.Shell.Extensions.GSConnect.pot
+++ b/po/org.gnome.Shell.Extensions.GSConnect.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-11 13:49-0400\n"
+"POT-Creation-Date: 2025-07-27 10:35+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -469,8 +469,14 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
+#: data/ui/preferences-shortcut-editor.ui:59
+msgid ""
+"Note that you have to first disable any conflicting shortucts in GNOME "
+"Settings."
+msgstr ""
+
 #. Keys for cancelling (␛) or resetting (␈) a shortcut
-#: data/ui/preferences-shortcut-editor.ui:80
+#: data/ui/preferences-shortcut-editor.ui:94
 msgid "Press Esc to cancel or Backspace to reset the keyboard shortcut."
 msgstr ""
 
@@ -640,13 +646,6 @@ msgstr ""
 #: src/preferences/keybindings.js:66
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
-msgstr ""
-
-#. TRANSLATORS: When a keyboard shortcut is unavailable
-#. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:132
-#, javascript-format
-msgid "%s is already being used"
 msgstr ""
 
 #: src/preferences/service.js:361

--- a/po/org.gnome.Shell.Extensions.GSConnect.pot
+++ b/po/org.gnome.Shell.Extensions.GSConnect.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-01 01:34-0400\n"
+"POT-Creation-Date: 2026-08-09 14:43+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,8 +98,8 @@ msgstr ""
 #: data/ui/preferences-shortcut-editor.ui:19
 #: data/ui/service-device-chooser.ui:21 data/ui/service-device-chooser.ui:25
 #: data/ui/service-error-dialog.ui:20 data/ui/service-error-dialog.ui:28
-#: src/preferences/service.js:417 src/service/plugins/share.js:179
-#: src/service/plugins/share.js:314 src/service/plugins/share.js:445
+#: src/preferences/service.js:417 src/service/plugins/share.js:188
+#: src/service/plugins/share.js:323 src/service/plugins/share.js:454
 msgid "Cancel"
 msgstr ""
 
@@ -125,20 +125,20 @@ msgid "Type a phone number or name"
 msgstr ""
 
 #. TRANSLATORS: All other phone number types
-#: data/ui/contacts-address-row.ui:71 src/service/ui/contacts.js:158
+#: data/ui/contacts-address-row.ui:71 src/service/ui/contacts.js:159
 msgid "Other"
 msgstr ""
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/legacy-messaging-dialog.ui:15 src/service/daemon.js:358
-#: src/service/daemon.js:481 src/service/plugins/sms.js:62
+#: data/ui/legacy-messaging-dialog.ui:15 src/service/daemon.js:359
+#: src/service/daemon.js:482 src/service/plugins/sms.js:62
 #: webextension/gettext.js:41
 msgid "Send SMS"
 msgstr ""
 
 #: data/ui/legacy-messaging-dialog.ui:32 data/ui/legacy-messaging-dialog.ui:36
 #: data/ui/notification-reply-dialog.ui:31
-#: data/ui/notification-reply-dialog.ui:35 src/service/plugins/share.js:446
+#: data/ui/notification-reply-dialog.ui:35 src/service/plugins/share.js:455
 msgid "Send"
 msgstr ""
 
@@ -151,7 +151,7 @@ msgstr ""
 msgid "Send Message"
 msgstr ""
 
-#: data/ui/messaging-conversation.ui:92 src/shell/notification.js:88
+#: data/ui/messaging-conversation.ui:92 src/shell/notification.js:89
 msgid "Type a message"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/ui/preferences-device-panel.ui:2624
-#: data/ui/preferences-device-panel.ui:2716 src/service/daemon.js:460
+#: data/ui/preferences-device-panel.ui:2716 src/service/daemon.js:461
 msgid "Pair"
 msgstr ""
 
@@ -425,7 +425,7 @@ msgid "Encryption Info"
 msgstr ""
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/ui/preferences-device-panel.ui:2722 src/service/daemon.js:469
+#: data/ui/preferences-device-panel.ui:2722 src/service/daemon.js:470
 msgid "Unpair"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgid ""
 "a>."
 msgstr ""
 
-#: data/ui/preferences-window.ui:874 src/service/init.js:361
+#: data/ui/preferences-window.ui:874 src/service/init.js:364
 msgid "OpenSSL not found"
 msgstr ""
 
@@ -624,8 +624,8 @@ msgstr ""
 #. context menu
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
 #. Update UI
-#: nautilus-extension/nautilus-gsconnect.py:187 src/service/ui/contacts.js:518
-#: src/service/ui/contacts.js:533
+#: nautilus-extension/nautilus-gsconnect.py:187 src/service/ui/contacts.js:519
+#: src/service/ui/contacts.js:534
 #, python-format, javascript-format
 msgid "Send to %s"
 msgstr ""
@@ -660,16 +660,9 @@ msgstr ""
 
 #. TRANSLATORS: Summary of a keyboard shortcut function
 #. Example: Enter a new shortcut to change Messaging
-#: src/preferences/keybindings.js:66
+#: src/preferences/keybindings.js:65
 #, javascript-format
 msgid "Enter a new shortcut to change <b>%s</b>"
-msgstr ""
-
-#. TRANSLATORS: When a keyboard shortcut is unavailable
-#. Example: [Ctrl]+[S] is already being used
-#: src/preferences/keybindings.js:132
-#, javascript-format
-msgid "%s is already being used"
 msgstr ""
 
 #: src/preferences/service.js:373
@@ -735,94 +728,94 @@ msgid "Waiting for service…"
 msgstr ""
 
 #. Notify the user
-#: src/service/daemon.js:103
+#: src/service/daemon.js:104
 msgid "Settings Migrated"
 msgstr ""
 
-#: src/service/daemon.js:104
+#: src/service/daemon.js:105
 msgid ""
 "GSConnect has updated to support changes to the KDE Connect protocol. Some "
 "devices may need to be re-paired."
 msgstr ""
 
-#: src/service/daemon.js:246
+#: src/service/daemon.js:247
 msgid "Click for help troubleshooting"
 msgstr ""
 
-#: src/service/daemon.js:256
+#: src/service/daemon.js:257
 msgid "Click for more information"
 msgstr ""
 
-#: src/service/daemon.js:364
+#: src/service/daemon.js:365
 msgid "Dial Number"
 msgstr ""
 
-#: src/service/daemon.js:370 src/service/daemon.js:568
+#: src/service/daemon.js:371 src/service/daemon.js:569
 #: src/service/plugins/share.js:31
 msgid "Share File"
 msgstr ""
 
-#: src/service/daemon.js:421
+#: src/service/daemon.js:422
 msgid "List available devices"
 msgstr ""
 
-#: src/service/daemon.js:430
+#: src/service/daemon.js:431
 msgid "List all devices"
 msgstr ""
 
-#: src/service/daemon.js:439
+#: src/service/daemon.js:440
 msgid "Target Device"
 msgstr ""
 
-#: src/service/daemon.js:448
+#: src/service/daemon.js:449
 msgid "Target Device Name"
 msgstr ""
 
-#: src/service/daemon.js:490
+#: src/service/daemon.js:491
 msgid "Message Body"
 msgstr ""
 
-#: src/service/daemon.js:502 src/service/plugins/notification.js:57
+#: src/service/daemon.js:503 src/service/plugins/notification.js:57
 msgid "Send Notification"
 msgstr ""
 
-#: src/service/daemon.js:511
+#: src/service/daemon.js:512
 msgid "Notification App Name"
 msgstr ""
 
-#: src/service/daemon.js:520
+#: src/service/daemon.js:521
 msgid "Notification Body"
 msgstr ""
 
-#: src/service/daemon.js:529
+#: src/service/daemon.js:530
 msgid "Notification Icon"
 msgstr ""
 
-#: src/service/daemon.js:538
+#: src/service/daemon.js:539
 msgid "Notification ID"
 msgstr ""
 
-#: src/service/daemon.js:547 src/service/plugins/ping.js:13
+#: src/service/daemon.js:548 src/service/plugins/ping.js:13
 #: src/service/plugins/ping.js:20 src/service/plugins/ping.js:47
 msgid "Ping"
 msgstr ""
 
-#: src/service/daemon.js:556 src/service/plugins/battery.js:247
+#: src/service/daemon.js:557 src/service/plugins/battery.js:247
 #: src/service/plugins/battery.js:276 src/service/plugins/battery.js:305
 #: src/service/plugins/findmyphone.js:22
 msgid "Ring"
 msgstr ""
 
-#: src/service/daemon.js:577 src/service/plugins/share.js:47
+#: src/service/daemon.js:578 src/service/plugins/share.js:47
 #: src/service/ui/messaging.js:1257 src/service/ui/messaging.js:1265
 msgid "Share Link"
 msgstr ""
 
-#: src/service/daemon.js:586 src/service/plugins/share.js:39
+#: src/service/daemon.js:587 src/service/plugins/share.js:39
 msgid "Share Text"
 msgstr ""
 
-#: src/service/daemon.js:598
+#: src/service/daemon.js:599
 msgid "Show release version"
 msgstr ""
 
@@ -871,7 +864,7 @@ msgid ""
 "Discovery has been disabled due to the number of devices on this network."
 msgstr ""
 
-#: src/service/backends/lan.js:477
+#: src/service/backends/lan.js:580
 msgid "Port already in use"
 msgstr ""
 
@@ -940,7 +933,7 @@ msgstr ""
 #. Contact Name
 #: src/service/plugins/contacts.js:242 src/service/plugins/contacts.js:362
 #: src/service/plugins/telephony.js:156 src/service/plugins/telephony.js:175
-#: src/service/ui/contacts.js:620 src/service/ui/messaging.js:756
+#: src/service/ui/contacts.js:621 src/service/ui/messaging.js:756
 msgid "Unknown Contact"
 msgstr ""
 
@@ -994,6 +987,10 @@ msgstr ""
 
 #: src/service/plugins/notification.js:65
 msgid "Activate Notification"
+msgstr ""
+
+#: src/service/plugins/notification.js:73
+msgid "Copy Text"
 msgstr ""
 
 #: src/service/plugins/ping.js:14
@@ -1054,87 +1051,87 @@ msgstr ""
 msgid "Share files and URLs between devices"
 msgstr ""
 
-#: src/service/plugins/share.js:148 src/service/plugins/share.js:227
-#: src/service/plugins/share.js:337
+#: src/service/plugins/share.js:157 src/service/plugins/share.js:236
+#: src/service/plugins/share.js:346
 msgid "Transfer Failed"
 msgstr ""
 
 #. TRANSLATORS: eg. Google Pixel is not allowed to upload files
-#: src/service/plugins/share.js:150
+#: src/service/plugins/share.js:159
 #, javascript-format
 msgid "%s is not allowed to upload files"
 msgstr ""
 
-#: src/service/plugins/share.js:172 src/service/plugins/share.js:307
+#: src/service/plugins/share.js:181 src/service/plugins/share.js:316
 msgid "Transferring File"
 msgstr ""
 
 #. TRANSLATORS: eg. Receiving 'book.pdf' from Google Pixel
-#: src/service/plugins/share.js:174
+#: src/service/plugins/share.js:183
 #, javascript-format
 msgid "Receiving “%s” from %s"
 msgstr ""
 
-#: src/service/plugins/share.js:193 src/service/plugins/share.js:327
+#: src/service/plugins/share.js:202 src/service/plugins/share.js:336
 msgid "Transfer Successful"
 msgstr ""
 
 #. TRANSLATORS: eg. Received 'book.pdf' from Google Pixel
-#: src/service/plugins/share.js:195
+#: src/service/plugins/share.js:204
 #, javascript-format
 msgid "Received “%s” from %s"
 msgstr ""
 
-#: src/service/plugins/share.js:205
+#: src/service/plugins/share.js:214
 msgid "Show File Location"
 msgstr ""
 
-#: src/service/plugins/share.js:210
+#: src/service/plugins/share.js:219
 msgid "Open File"
 msgstr ""
 
 #. TRANSLATORS: eg. Failed to receive 'book.pdf' from Google Pixel
-#: src/service/plugins/share.js:229
+#: src/service/plugins/share.js:238
 #, javascript-format
 msgid "Failed to receive “%s” from %s"
 msgstr ""
 
-#: src/service/plugins/share.js:259
+#: src/service/plugins/share.js:268
 #, javascript-format
 msgid "Text Shared By %s"
 msgstr ""
 
 #. TRANSLATORS: eg. Sending 'book.pdf' to Google Pixel
-#: src/service/plugins/share.js:309
+#: src/service/plugins/share.js:318
 #, javascript-format
 msgid "Sending “%s” to %s"
 msgstr ""
 
 #. TRANSLATORS: eg. Sent "book.pdf" to Google Pixel
-#: src/service/plugins/share.js:329
+#: src/service/plugins/share.js:338
 #, javascript-format
 msgid "Sent “%s” to %s"
 msgstr ""
 
 #. TRANSLATORS: eg. Failed to send "book.pdf" to Google Pixel
-#: src/service/plugins/share.js:339
+#: src/service/plugins/share.js:348
 #, javascript-format
 msgid "Failed to send “%s” to %s"
 msgstr ""
 
 #. TRANSLATORS: eg. Send files to Google Pixel
-#: src/service/plugins/share.js:397
+#: src/service/plugins/share.js:406
 #, javascript-format
 msgid "Send files to %s"
 msgstr ""
 
 #. TRANSLATORS: Mark the file to be opened once completed
-#: src/service/plugins/share.js:401
+#: src/service/plugins/share.js:410
 msgid "Open when done"
 msgstr ""
 
 #. TRANSLATORS: eg. Send a link to Google Pixel
-#: src/service/plugins/share.js:440
+#: src/service/plugins/share.js:449
 #, javascript-format
 msgid "Send a link to %s"
 msgstr ""
@@ -1192,22 +1189,22 @@ msgid "Ongoing call"
 msgstr ""
 
 #. TRANSLATORS: A fax number
-#: src/service/ui/contacts.js:143
+#: src/service/ui/contacts.js:144
 msgid "Fax"
 msgstr ""
 
 #. TRANSLATORS: A work or office phone number
-#: src/service/ui/contacts.js:147
+#: src/service/ui/contacts.js:148
 msgid "Work"
 msgstr ""
 
 #. TRANSLATORS: A mobile or cellular phone number
-#: src/service/ui/contacts.js:151
+#: src/service/ui/contacts.js:152
 msgid "Mobile"
 msgstr ""
 
 #. TRANSLATORS: A home phone number
-#: src/service/ui/contacts.js:155
+#: src/service/ui/contacts.js:156
 msgid "Home"
 msgstr ""
 
@@ -1277,7 +1274,7 @@ msgstr ""
 msgid "%d%% (%d∶%02d Remaining)"
 msgstr ""
 
-#: src/shell/notification.js:73
+#: src/shell/notification.js:74
 msgid "Reply"
 msgstr ""
 

--- a/src/preferences/keybindings.js
+++ b/src/preferences/keybindings.js
@@ -4,7 +4,6 @@
 
 import Gdk from 'gi://Gdk';
 import Gio from 'gi://Gio';
-import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk';
 

--- a/src/preferences/keybindings.js
+++ b/src/preferences/keybindings.js
@@ -135,7 +135,7 @@ export const ShortcutChooserDialog = GObject.registerClass({
         return true;
     }
 
-    async _check() {
+    _check() {
         try {
             // No known way to check availability, so don't. Don't grab input,
             // so we don't accidentally overload accelerators as easily

--- a/src/preferences/keybindings.js
+++ b/src/preferences/keybindings.js
@@ -122,8 +122,6 @@ export const ShortcutChooserDialog = GObject.registerClass({
         realMask &= ~Gdk.ModifierType.LOCK_MASK;
 
         if (keyvalLower !== 0 && realMask !== 0) {
-            this._ungrab();
-
             // Set the accelerator property/label
             this.accelerator = Gtk.accelerator_name(keyvalLower, realMask);
 
@@ -145,7 +143,9 @@ export const ShortcutChooserDialog = GObject.registerClass({
 
     async _check() {
         try {
-            const available = await checkAccelerator(this.accelerator);
+            // No known way to check availability, so don't. Don't grab input,
+            // so we don't accidentally overload accelerators as easily
+            const available = true;
             this.set_button.visible = available;
             this.conflict_label.visible = !available;
         } catch (e) {
@@ -154,117 +154,11 @@ export const ShortcutChooserDialog = GObject.registerClass({
         }
     }
 
-    _grab() {
-        const success = this._seat.grab(
-            this.get_window(),
-            Gdk.SeatCapabilities.KEYBOARD,
-            true, // owner_events
-            null, // cursor
-            null, // event
-            null
-        );
-
-        if (success !== Gdk.GrabStatus.SUCCESS)
-            return this.response(ResponseType.CANCEL);
-
-        if (!this._seat.get_keyboard() && !this._seat.get_pointer())
-            return this.response(ResponseType.CANCEL);
-
-        this.grab_add();
-    }
-
-    _ungrab() {
-        this._seat.ungrab();
-        this.grab_remove();
-    }
-
-    // Override to use our own ungrab process
-    response(response_id) {
-        this.hide();
-        this._ungrab();
-
-        return super.response(response_id);
-    }
-
     // Override with a non-blocking version of Gtk.Dialog.run()
     run() {
         this.show();
-
-        // Wait a bit before attempting grab
-        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
-            this._grab();
-            return GLib.SOURCE_REMOVE;
-        });
     }
 });
-
-
-/**
- * Check the availability of an accelerator using GNOME Shell's DBus interface.
- *
- * @param {string} accelerator - An accelerator
- * @param {number} [modeFlags] - Mode Flags
- * @param {number} [grabFlags] - Grab Flags
- * @returns {boolean} %true if available, %false on error or unavailable
- */
-export async function checkAccelerator(accelerator, modeFlags = 0, grabFlags = 0) {
-    try {
-        let result = false;
-
-        // Try to grab the accelerator
-        const action = await new Promise((resolve, reject) => {
-            Gio.DBus.session.call(
-                'org.gnome.Shell',
-                '/org/gnome/Shell',
-                'org.gnome.Shell',
-                'GrabAccelerator',
-                new GLib.Variant('(suu)', [accelerator, modeFlags, grabFlags]),
-                null,
-                Gio.DBusCallFlags.NONE,
-                -1,
-                null,
-                (connection, res) => {
-                    try {
-                        res = connection.call_finish(res);
-                        resolve(res.deepUnpack()[0]);
-                    } catch (e) {
-                        reject(e);
-                    }
-                }
-            );
-        });
-
-        // If successful, use the result of ungrabbing as our return
-        if (action !== 0) {
-            result = await new Promise((resolve, reject) => {
-                Gio.DBus.session.call(
-                    'org.gnome.Shell',
-                    '/org/gnome/Shell',
-                    'org.gnome.Shell',
-                    'UngrabAccelerator',
-                    new GLib.Variant('(u)', [action]),
-                    null,
-                    Gio.DBusCallFlags.NONE,
-                    -1,
-                    null,
-                    (connection, res) => {
-                        try {
-                            res = connection.call_finish(res);
-                            resolve(res.deepUnpack()[0]);
-                        } catch (e) {
-                            reject(e);
-                        }
-                    }
-                );
-            });
-        }
-
-        return result;
-    } catch (e) {
-        logError(e);
-        return false;
-    }
-}
 
 
 /**

--- a/src/preferences/keybindings.js
+++ b/src/preferences/keybindings.js
@@ -46,7 +46,7 @@ export const ShortcutChooserDialog = GObject.registerClass({
     Children: [
         'cancel-button', 'set-button',
         'stack', 'summary-label',
-        'shortcut-label', 'conflict-label',
+        'shortcut-label',
     ],
 }, class ShortcutChooserDialog extends Gtk.Dialog {
 
@@ -125,13 +125,7 @@ export const ShortcutChooserDialog = GObject.registerClass({
             // Set the accelerator property/label
             this.accelerator = Gtk.accelerator_name(keyvalLower, realMask);
 
-            // TRANSLATORS: When a keyboard shortcut is unavailable
-            // Example: [Ctrl]+[S] is already being used
-            this.conflict_label.label = _('%s is already being used').format(
-                Gtk.accelerator_get_label(keyvalLower, realMask)
-            );
-
-            // Show Cancel button and switch to confirm/conflict page
+            // Show Cancel button and switch to confirm page
             this.cancel_button.visible = true;
             this.stack.visible_child_name = 'confirm';
 
@@ -147,7 +141,6 @@ export const ShortcutChooserDialog = GObject.registerClass({
             // so we don't accidentally overload accelerators as easily
             const available = true;
             this.set_button.visible = available;
-            this.conflict_label.visible = !available;
         } catch (e) {
             logError(e);
             this.response(ResponseType.CANCEL);

--- a/src/preferences/keybindings.js
+++ b/src/preferences/keybindings.js
@@ -136,8 +136,8 @@ export const ShortcutChooserDialog = GObject.registerClass({
 
     _check() {
         try {
-            // No known way to check availability, so don't. Don't grab input,
-            // so we don't accidentally overload accelerators as easily
+            // No known sane way to check availability, so don't. Don't grab
+            // input, so we don't accidentally overload accelerators as easily
             const available = true;
             this.set_button.visible = available;
         } catch (e) {


### PR DESCRIPTION
It's been [almost 4 years](https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/1215), I don't have the feeling that we'll actually implement a way of checking for conflicts. I suggest we instead drop grabbing the keyboard, so if there's already a global shortcut for something, then it just won't be passed to us in the dialog. I added a note in the dialog instructing the user to first disable shortcuts in GNOME Settings.

For some reason the [pot/po updating commands](https://github.com/GSConnect/gnome-shell-extension-gsconnect/wiki/Translating#creating-a-translation) wanted to update a bunch of line breaks. Is this something that goes back and forth, or a progress moves forward type of thing? If it's back and forth then I can minimize the diff to just the actually changed parts, but if it's just old vs new tools then maybe we can rip the bandaid and have the larger diff here.