### PR TITLE
improve sftp mounts

### DIFF
--- a/src/service/plugins/sftp.js
+++ b/src/service/plugins/sftp.js
@@ -7,6 +7,7 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 
 import Config from '../../config.js';
+import * as Core from '../core.js';
 import Plugin from '../plugin.js';
 
 
@@ -212,7 +213,7 @@ const SFTPPlugin = GObject.registerClass({
 
             // We're just updating the submenu if we're already mounted
             if (this._gmount !== null) {
-                await this._addSubmenu(this._gmount);
+                this._addSubmenu(this._gmount);
                 if (this._userRequested) {
                     this._userRequested = false;
                     this._openDirectory(this._gmount);
@@ -226,7 +227,7 @@ const SFTPPlugin = GObject.registerClass({
                 const mountUri = mount.get_root().get_uri();
                 if (regex.test(mountUri)) {
                     this._gmount = mount;
-                    await this._addSubmenu(mount);
+                    this._addSubmenu(mount);
                     if (this._userRequested) {
                         this._userRequested = false;
                         this._openDirectory(mount);
@@ -278,7 +279,7 @@ const SFTPPlugin = GObject.registerClass({
                     const mountUri = mount.get_root().get_uri();
                     if (regex.test(mountUri)) {
                         this._gmount = mount;
-                        await this._addSubmenu(mount);
+                        this._addSubmenu(mount);
                         if (this._userRequested)
                             this._openDirectory(mount);
                         return;
@@ -380,7 +381,8 @@ const SFTPPlugin = GObject.registerClass({
         if (this._remoteDirectories !== null) {
             const entries = Object.entries(this._remoteDirectories);
             if (entries.length > 0) {
-                const [name, path] = entries[0];
+                // eslint-disable-next-line no-unused-vars
+                const [_name, path] = entries[0];
                 Gio.AppInfo.launch_default_for_uri_async(
                     `${baseUri}${path.replace(/^\//, '')}/`, null, null, null);
                 return;
@@ -396,7 +398,7 @@ const SFTPPlugin = GObject.registerClass({
      *
      * @param {Gio.Mount} mount - The GMount
      */
-    async _addSubmenu(mount) {
+    _addSubmenu(mount) {
         try {
             const filesMenuItem = this._createFilesMenuItem();
 


### PR DESCRIPTION
Well, this stuff is super complicated.
I probably did a lot of things not right but it works for me pretty well now.

I removed the symlink logic: I love it visually but it is indeed suuuuuuuuuuuper slow for some reason.
And I'm [not the only one](https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/1610#issuecomment-3096126804) who realised this.

And regarding the deep link mount: I think it is related to [this upstream bug](https://gitlab.gnome.org/GNOME/gvfs/-/issues/625#note_1448225).
So we can't tackle this until the SFTP issue is solved but this PR will simply open Nautilus at the mount point for now.

…ooor we decide to abandon gvfs. :wink: 

fixes #1203 #1861 #1857 #1794 #1610