### PR TITLE
Added name option for CLI

### DIFF
--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -773,7 +773,6 @@ const Service = GObject.registerClass({
                 const name = options.lookup_value('name', null).unpack();
                 id = this._findDeviceID(name); // May return null if no match found
             }
-            
             if (id === null)
                 return -1;
             // Pairing


### PR DESCRIPTION
This PR lets you write commands using only the device name.
```bash
./daemon.js --name "MyDeviceName" --ring
./daemon.js -n "MyDeviceName" --ring
```
This adds readability and ease of use to the CLI.