### PR TITLE
Adds inital support for mDNS discovery via the dbus interface of avahi

### DIFF
--- a/src/service/backends/avahi/avahi-dbus.js
+++ b/src/service/backends/avahi/avahi-dbus.js
@@ -1,0 +1,345 @@
+// SPDX-FileCopyrightText: GSConnect Developers https://github.com/GSConnect
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import Gio from 'gi://Gio';
+
+const xmlDef = `
+<node>
+  <interface name="org.freedesktop.Avahi.Server2">
+
+    <method name="GetVersionString">
+      <arg name="version" type="s" direction="out"/>
+    </method>
+
+    <method name="GetAPIVersion">
+      <arg name="version" type="u" direction="out"/>
+    </method>
+
+    <method name="GetHostName">
+      <arg name="name" type="s" direction="out"/>
+    </method>
+    <method name="SetHostName">
+      <arg name="name" type="s" direction="in"/>
+    </method>
+    <method name="GetHostNameFqdn">
+      <arg name="name" type="s" direction="out"/>
+    </method>
+    <method name="GetDomainName">
+      <arg name="name" type="s" direction="out"/>
+    </method>
+
+    <method name="IsNSSSupportAvailable">
+      <arg name="yes" type="b" direction="out"/>
+    </method>
+
+    <method name="GetState">
+      <arg name="state" type="i" direction="out"/>
+    </method>
+
+    <signal name="StateChanged">
+      <arg name="state" type="i"/>
+      <arg name="error" type="s"/>
+    </signal>
+
+    <method name="GetLocalServiceCookie">
+      <arg name="cookie" type="u" direction="out"/>
+    </method>
+
+    <method name="GetAlternativeHostName">
+      <arg name="name" type="s" direction="in"/>
+      <arg name="name" type="s" direction="out"/>
+    </method>
+
+    <method name="GetAlternativeServiceName">
+      <arg name="name" type="s" direction="in"/>
+      <arg name="name" type="s" direction="out"/>
+    </method>
+
+    <method name="GetNetworkInterfaceNameByIndex">
+      <arg name="index" type="i" direction="in"/>
+      <arg name="name" type="s" direction="out"/>
+    </method>
+    <method name="GetNetworkInterfaceIndexByName">
+      <arg name="name" type="s" direction="in"/>
+      <arg name="index" type="i" direction="out"/>
+    </method>
+
+    <method name="ResolveHostName">
+      <arg name="interface" type="i" direction="in"/>
+      <arg name="protocol" type="i" direction="in"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="aprotocol" type="i" direction="in"/>
+      <arg name="flags" type="u" direction="in"/>
+
+      <arg name="interface" type="i" direction="out"/>
+      <arg name="protocol" type="i" direction="out"/>
+      <arg name="name" type="s" direction="out"/>
+      <arg name="aprotocol" type="i" direction="out"/>
+      <arg name="address" type="s" direction="out"/>
+      <arg name="flags" type="u" direction="out"/>
+    </method>
+
+    <method name="ResolveAddress">
+      <arg name="interface" type="i" direction="in"/>
+      <arg name="protocol" type="i" direction="in"/>
+      <arg name="address" type="s" direction="in"/>
+      <arg name="flags" type="u" direction="in"/>
+
+      <arg name="interface" type="i" direction="out"/>
+      <arg name="protocol" type="i" direction="out"/>
+      <arg name="aprotocol" type="i" direction="out"/>
+      <arg name="address" type="s" direction="out"/>
+      <arg name="name" type="s" direction="out"/>
+      <arg name="flags" type="u" direction="out"/>
+    </method>
+
+    <method name="ResolveService">
+      <arg name="interface" type="i" direction="in"/>
+      <arg name="protocol" type="i" direction="in"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="type" type="s" direction="in"/>
+      <arg name="domain" type="s" direction="in"/>
+      <arg name="aprotocol" type="i" direction="in"/>
+      <arg name="flags" type="u" direction="in"/>
+
+      <arg name="interface" type="i" direction="out"/>
+      <arg name="protocol" type="i" direction="out"/>
+      <arg name="name" type="s" direction="out"/>
+      <arg name="type" type="s" direction="out"/>
+      <arg name="domain" type="s" direction="out"/>
+      <arg name="host" type="s" direction="out"/>
+      <arg name="aprotocol" type="i" direction="out"/>
+      <arg name="address" type="s" direction="out"/>
+      <arg name="port" type="q" direction="out"/>
+      <arg name="txt" type="aay" direction="out"/>
+      <arg name="flags" type="u" direction="out"/>
+    </method>
+
+    <method name="EntryGroupNew">
+      <arg name="path" type="o" direction="out"/>
+    </method>
+
+    <method name="DomainBrowserPrepare">
+      <arg name="interface" type="i" direction="in"/>
+      <arg name="protocol" type="i" direction="in"/>
+      <arg name="domain" type="s" direction="in"/>
+      <arg name="btype" type="i" direction="in"/>
+      <arg name="flags" type="u" direction="in"/>
+
+      <arg name="path" type="o" direction="out"/>
+    </method>
+
+    <method name="ServiceTypeBrowserPrepare">
+      <arg name="interface" type="i" direction="in"/>
+      <arg name="protocol" type="i" direction="in"/>
+      <arg name="domain" type="s" direction="in"/>
+      <arg name="flags" type="u" direction="in"/>
+
+      <arg name="path" type="o" direction="out"/>
+    </method>
+
+    <method name="ServiceBrowserPrepare">
+      <arg name="interface" type="i" direction="in"/>
+      <arg name="protocol" type="i" direction="in"/>
+      <arg name="type" type="s" direction="in"/>
+      <arg name="domain" type="s" direction="in"/>
+      <arg name="flags" type="u" direction="in"/>
+
+      <arg name="path" type="o" direction="out"/>
+    </method>
+
+    <method name="ServiceResolverPrepare">
+      <arg name="interface" type="i" direction="in"/>
+      <arg name="protocol" type="i" direction="in"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="type" type="s" direction="in"/>
+      <arg name="domain" type="s" direction="in"/>
+      <arg name="aprotocol" type="i" direction="in"/>
+      <arg name="flags" type="u" direction="in"/>
+
+      <arg name="path" type="o" direction="out"/>
+    </method>
+
+    <method name="HostNameResolverPrepare">
+      <arg name="interface" type="i" direction="in"/>
+      <arg name="protocol" type="i" direction="in"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="aprotocol" type="i" direction="in"/>
+      <arg name="flags" type="u" direction="in"/>
+
+      <arg name="path" type="o" direction="out"/>
+    </method>
+
+    <method name="AddressResolverPrepare">
+      <arg name="interface" type="i" direction="in"/>
+      <arg name="protocol" type="i" direction="in"/>
+      <arg name="address" type="s" direction="in"/>
+      <arg name="flags" type="u" direction="in"/>
+
+      <arg name="path" type="o" direction="out"/>
+    </method>
+
+    <method name="RecordBrowserPrepare">
+      <arg name="interface" type="i" direction="in"/>
+      <arg name="protocol" type="i" direction="in"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="clazz" type="q" direction="in"/>
+      <arg name="type" type="q" direction="in"/>
+      <arg name="flags" type="u" direction="in"/>
+
+      <arg name="path" type="o" direction="out"/>
+    </method>
+
+  </interface>
+</node>
+`;
+
+const xmlEntry = `
+<node>
+  <interface name="org.freedesktop.Avahi.EntryGroup">
+    <method name="Free"/>
+    <method name="Commit"/>
+    <method name="Reset"/>
+
+    <method name="GetState">
+      <arg name="state" type="i" direction="out"/>
+    </method>
+
+    <signal name="StateChanged">
+      <arg name="state" type="i"/>
+      <arg name="error" type="s"/>
+    </signal>
+
+    <method name="IsEmpty">
+      <arg name="empty" type="b" direction="out"/>
+    </method>
+
+    <method name="AddService">
+      <arg name="interface" type="i" direction="in"/>
+      <arg name="protocol" type="i" direction="in"/>
+      <arg name="flags" type="u" direction="in"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="type" type="s" direction="in"/>
+      <arg name="domain" type="s" direction="in"/>
+      <arg name="host" type="s" direction="in"/>
+      <arg name="port" type="q" direction="in"/>
+      <arg name="txt" type="aay" direction="in"/>
+    </method>
+
+    <method name="AddServiceSubtype">
+      <arg name="interface" type="i" direction="in"/>
+      <arg name="protocol" type="i" direction="in"/>
+      <arg name="flags" type="u" direction="in"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="type" type="s" direction="in"/>
+      <arg name="domain" type="s" direction="in"/>
+      <arg name="subtype" type="s" direction="in"/>
+    </method>
+
+    <method name="UpdateServiceTxt">
+      <arg name="interface" type="i" direction="in"/>
+      <arg name="protocol" type="i" direction="in"/>
+      <arg name="flags" type="u" direction="in"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="type" type="s" direction="in"/>
+      <arg name="domain" type="s" direction="in"/>
+      <arg name="txt" type="aay" direction="in"/>
+    </method>
+
+    <method name="AddAddress">
+      <arg name="interface" type="i" direction="in"/>
+      <arg name="protocol" type="i" direction="in"/>
+      <arg name="flags" type="u" direction="in"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="address" type="s" direction="in"/>
+    </method>
+
+    <method name="AddRecord">
+      <arg name="interface" type="i" direction="in"/>
+      <arg name="protocol" type="i" direction="in"/>
+      <arg name="flags" type="u" direction="in"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="clazz" type="q" direction="in"/>
+      <arg name="type" type="q" direction="in"/>
+      <arg name="ttl" type="u" direction="in"/>
+      <arg name="rdata" type="ay" direction="in"/>
+    </method>
+  </interface>
+</node>
+`;
+
+const xmlServiceBrowser = `
+<node>
+  <interface name="org.freedesktop.Avahi.ServiceBrowser">
+
+    <method name="Free"/>
+
+    <method name="Start"/>
+
+    <signal name="ItemNew">
+      <arg name="interface" type="i"/>
+      <arg name="protocol" type="i"/>
+      <arg name="name" type="s"/>
+      <arg name="type" type="s"/>
+      <arg name="domain" type="s"/>
+      <arg name="flags" type="u"/>
+    </signal>
+
+    <signal name="ItemRemove">
+      <arg name="interface" type="i"/>
+      <arg name="protocol" type="i"/>
+      <arg name="name" type="s"/>
+      <arg name="type" type="s"/>
+      <arg name="domain" type="s"/>
+      <arg name="flags" type="u"/>
+    </signal>
+
+    <signal name="Failure">
+      <arg name="error" type="s"/>
+    </signal>
+
+    <signal name="AllForNow"/>
+
+    <signal name="CacheExhausted"/>
+
+  </interface>
+</node>
+`;
+
+const xmlServiceResolve = `
+<node>
+  <interface name="org.freedesktop.Avahi.ServiceResolver">
+
+    <method name="Free"/>
+
+    <method name="Start"/>
+
+    <signal name="Found">
+      <arg name="interface" type="i" direction="out"/>
+      <arg name="protocol" type="i" direction="out"/>
+      <arg name="name" type="s" direction="out"/>
+      <arg name="type" type="s" direction="out"/>
+      <arg name="domain" type="s" direction="out"/>
+      <arg name="host" type="s" direction="out"/>
+      <arg name="aprotocol" type="i" direction="out"/>
+      <arg name="address" type="s" direction="out"/>
+      <arg name="port" type="q" direction="out"/>
+      <arg name="txt" type="aay" direction="out"/>
+      <arg name="flags" type="u" direction="out"/>
+    </signal>
+
+    <signal name="Failure">
+      <arg name="error" type="s"/>
+    </signal>
+
+  </interface>
+</node>
+`;
+
+const AvahiServer = Gio.DBusProxy.makeProxyWrapper(xmlDef);
+const AvahiGroup = Gio.DBusProxy.makeProxyWrapper(xmlEntry);
+const AvahiServiceBrowser = Gio.DBusProxy.makeProxyWrapper(xmlServiceBrowser);
+const AvahiServiceResolve = Gio.DBusProxy.makeProxyWrapper(xmlServiceResolve);
+
+export {AvahiServer, AvahiGroup, AvahiServiceBrowser, AvahiServiceResolve};

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -10,6 +10,8 @@ import Config from '../../config.js';
 import * as Core from '../core.js';
 import Device from '../device.js';
 
+import {AvahiServer, AvahiGroup, AvahiServiceBrowser} from  './avahi/avahi-dbus.js';
+
 // Retain compatibility with GLib < 2.80, which lacks GioUnix
 let GioUnix;
 try {
@@ -30,6 +32,12 @@ const PROTOCOL_PORT_MAX = 1764;
 const TRANSFER_MIN = 1739;
 const TRANSFER_MAX = 1764;
 
+
+/**
+ * Avahi Constants
+ */
+const DBUS_AVAHI = 'org.freedesktop.Avahi';
+const KDE_CONNECT_SERVICE_TYPE = '_kdeconnect._udp';
 
 /*
  * One-time check for Linux/FreeBSD socket options
@@ -125,6 +133,16 @@ export const ChannelService = GObject.registerClass({
         this._networkMonitor = Gio.NetworkMonitor.get_default();
         this._networkAvailable = false;
         this._networkChangedId = 0;
+
+        this._avahiAvaible = false;
+        this._avahiGroup = null;
+        this._avahiServer = null;
+        this._avahiServiceBrowser = null;
+        this._discoverySignal = null;
+
+        this._dbusWatchID = Gio.bus_watch_name(Gio.BusType.SYSTEM, DBUS_AVAHI,
+            Gio.BusNameWatcherFlags.NONE, this._initAvahi.bind(this), null);
+
     }
 
     get certificate() {
@@ -222,6 +240,74 @@ export const ChannelService = GObject.registerClass({
 
             throw e;
         }
+    }
+
+    _initAvahi(connection, name, _owner) {
+        try {
+            this._avahiServer = new AvahiServer(connection, name, '/',
+                null, null, Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES);
+        } catch (e) {
+            logError(e);
+            return;
+        }
+
+        try {
+            const entry_path = this._avahiServer.EntryGroupNewSync()[0];
+            this._avahiGroup = new AvahiGroup(
+                connection,
+                name,
+                entry_path, null, null,
+                Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES);
+        } catch (e) {
+            logError(e);
+            return;
+        }
+        const utf8Encode = new TextEncoder();
+        const txtRecords = [`id=${this.id.trim()}`,
+            `name=${this.name.trim()}`,
+            `type=${Core._getDeviceType().trim()}`,
+            'protocol=8'].map((x) => utf8Encode.encode(x));
+
+        this._avahiGroup.AddServiceSync(-1, -1, 64, `${this.identity.body.deviceId}`,
+            KDE_CONNECT_SERVICE_TYPE,
+            '',
+            '',
+            this.port,
+            txtRecords);
+        // setup service Browser, but don't start it yet
+        try {
+            const service_path = this._avahiServer.ServiceBrowserPrepareSync(-1, -1,
+                KDE_CONNECT_SERVICE_TYPE,
+                '', 0)[0];
+
+            this._avahiServiceBrowser = new AvahiServiceBrowser(connection,
+                name,
+                service_path,
+                null,
+                null,
+                Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES);
+        } catch (e) {
+            logError(e);
+            return;
+        }
+
+        const callback = this._ahaviServiceDiscoveryCallback.bind(this);
+        this._discoverySignal = this._avahiServiceBrowser.connectSignal('ItemNew', callback);
+        // register service and mark avahi as avaible
+        this._avahiGroup.CommitSync();
+        if (this._active)
+            this._avahiServiceBrowser.StartSync();
+
+        this._avahiAvaible = true;
+    }
+
+    _ahaviServiceDiscoveryCallback(proxy, name, args) {
+        if (args[2] === this.identity.body.deviceId)
+            return;
+
+        const resolve = this._avahiServer.ResolveServiceSync(args[0], args[1], args[2], args[3], args[4], -1, 0);
+        debug(`sending packet:${resolve[7]} (${args[2]})`);
+        this.broadcast(resolve[7]);
     }
 
     async _onIncomingChannel(listener, connection) {
@@ -487,6 +573,8 @@ export const ChannelService = GObject.registerClass({
             this._networkChangedId = this._networkMonitor.connect(
                 'network-changed', this._onNetworkChanged.bind(this));
         }
+        if (this._avahiAvaible)
+            this._avahiServiceBrowser.StartSync();
 
         this._active = true;
         this.notify('active');
@@ -522,6 +610,14 @@ export const ChannelService = GObject.registerClass({
         for (const channel of this.channels.values())
             channel.close();
 
+        if (this._avahiAvaible) {
+            this._avahiServiceBrowser.disconnectSignal(this._discoverySignal);
+            this._avahiServiceBrowser.FreeSync();
+            this._avahiGroup.ResetSync();
+            this._avahiGroup.FreeSync();
+            this.Gio.bus_unown_name(this._dbusWatchID);
+            this._avahiAvaible = false;
+        }
         this._active = false;
         this.notify('active');
     }


### PR DESCRIPTION
Inital mdns support so it works on enterprise WiFi deployments that only allow mdns based discovery and block broadcast.

I'm not too familiar with the gio/gjs dbus behavoir and if in the current setup this will gracefully not work on systems that don't have dbus running or available. Otherwise some extra fencing needs to be added if there is a easier way to detect if dbus is available on the system.

Feedback/ pointers are welcome. I personally have not a lot of JavaScript experience so if there are any obvious things that should be changed/improved feel free to let me know.

This closes #1654