### PR TITLE
Use DesktopAppInfo from GioUnix, if possible

### DIFF
--- a/src/service/components/notification.js
+++ b/src/service/components/notification.js
@@ -9,6 +9,12 @@ import GObject from 'gi://GObject';
 
 import * as DBus from '../utils/dbus.js';
 
+// DesktopAppInfo is no longer in Gio in GNOME 49
+let GioUnix;
+GioUnix = import('gi://GioUnix?version=2.0').catch(() => {
+    GioUnix = Gio;
+});
+
 
 const _nodeInfo = Gio.DBusNodeInfo.new_for_xml(`
 <node>
@@ -100,7 +106,7 @@ const Listener = GObject.registerClass({
                 path: `/org/gnome/desktop/notifications/application/${app}/`,
             });
 
-            const appInfo = Gio.DesktopAppInfo.new(
+            const appInfo = GioUnix.DesktopAppInfo.new(
                 appSettings.get_string('application-id')
             );
 
@@ -198,7 +204,7 @@ const Listener = GObject.registerClass({
 
         try {
             const appId = await this._getAppId(sender, appName);
-            const appInfo = Gio.DesktopAppInfo.new(`${appId}.desktop`);
+            const appInfo = GioUnix.DesktopAppInfo.new(`${appId}.desktop`);
             this._names[appName] = appInfo.get_name();
             appName = appInfo.get_name();
         } catch {
@@ -357,7 +363,7 @@ const Listener = GObject.registerClass({
         if (application === 'org.gnome.Shell.Extensions.GSConnect')
             return;
 
-        const appInfo = Gio.DesktopAppInfo.new(`${application}.desktop`);
+        const appInfo = GioUnix.DesktopAppInfo.new(`${application}.desktop`);
 
         // Try to get an icon for the notification
         if (!notification.hasOwnProperty('icon'))

--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -17,7 +17,11 @@ import('gi://GIRepository?version=3.0').catch(() => {
     import('gi://GIRepository?version=2.0').catch(() => {});
 });
 
-import('gi://GioUnix?version=2.0').catch(() => {}); // Set version for optional dependency
+// DesktopAppInfo is no longer in Gio in GNOME 49
+let GioUnix;
+GioUnix = import('gi://GioUnix?version=2.0').catch(() => {
+    GioUnix = Gio;
+});
 
 import system from 'system';
 
@@ -296,7 +300,7 @@ const Service = GObject.registerClass({
 
         // Ensure our handlers are registered
         try {
-            const appInfo = Gio.DesktopAppInfo.new(`${Config.APP_ID}.desktop`);
+            const appInfo = GioUnix.DesktopAppInfo.new(`${Config.APP_ID}.desktop`);
             appInfo.add_supports_type('x-scheme-handler/sms');
             appInfo.add_supports_type('x-scheme-handler/tel');
         } catch (e) {


### PR DESCRIPTION
The compatibility symbols providing Gio.DesktopAppInfo even after its move to GioUnix were officially deprecated in GNOME 49, so we should use GioUnix.DesktopAppInfo directly if possible.

Fixes #2116