### PR TITLE
Add Device.validateLocalId for migration

### DIFF
--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -66,7 +66,7 @@ const Service = GObject.registerClass({
 
         const certificate = Gio.TlsCertificate.new_for_paths(certPath, keyPath, null);
 
-        if (Device.validateId(certificate.common_name))
+        if (Device.validateLocalId(certificate.common_name))
             return;
 
         // Remove the old certificate, serving as the single source of truth

--- a/src/service/device.js
+++ b/src/service/device.js
@@ -139,6 +139,10 @@ const Device = GObject.registerClass({
         return /^[a-zA-Z0-9_-]{32,38}$/.test(id);
     }
 
+    static validateLocalId(id) {
+        return /^[a-zA-Z0-9_]{32,38}$/.test(id);
+    }
+
     static validateName(name) {
         // None of the forbidden characters and at least one non-whitespace
         return name.trim() && /^[^"',;:.!?()[\]<>]{1,32}$/.test(name);


### PR DESCRIPTION
The `Device.validateId()` function was made more liberal just prior to the release of v61 (or was it v66?), breaking its use in `_migrateConfiguration()` to trigger resetting of invalid device IDs. (It accepts hyphenated UUIDs, which we no longer want to consider valid local device IDs.)

KDE Connect 1.35 has stopped accepting hyphenated IDs, so we really need to force migration of those. To facilitate that, add a new `Device.validateLocalId()` that accepts only UUID strings without separators, or with underscore separators (no hyphens), and use that in `_migrateConfiguration()`.

Fixes #2133