### PR TITLE
Filter `journalctl` dump for support log using syslog identifier

### DIFF
--- a/src/preferences/service.js
+++ b/src/preferences/service.js
@@ -52,7 +52,7 @@ async function generateSupportLog(time) {
         const proc = new Gio.Subprocess({
             flags: (Gio.SubprocessFlags.STDOUT_PIPE |
                     Gio.SubprocessFlags.STDERR_MERGE),
-            argv: ['journalctl', '--no-host', '--since', time],
+            argv: ['journalctl', '--no-host', '--since', time, '--identifier', 'org.gnome.Shell.Extensions.GSConnect'],
         });
         proc.init(null);
 


### PR DESCRIPTION
I was trying to debug a different issue and noticed the support log was full of garbage from other processes. This PR adds an extra argument to the `journalctl` invocation to also filter by the syslog ID, meaning only GSConnect messages logs will be included. Due to the fact its only a single line change I didn't think opening an issue would be useful.