### PR TITLE
Add GNOME 50 to supported versions

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -3,6 +3,6 @@
     "name": "GSConnect",
     "description": "GSConnect is a complete implementation of KDE Connect especially for GNOME Shell with Nautilus, Chrome and Firefox integration. It does not rely on the KDE Connect desktop application and will not work with it installed.\n\nKDE Connect allows devices to securely share content like notifications or files and other features like SMS messaging and remote control. The KDE Connect team has applications for Linux, BSD, Android, Sailfish, iOS, macOS and Windows.\n\nPlease report issues on Github!",
     "version": @PACKAGE_VERSION@,
-    "shell-version": [ "46", "47", "48", "49" ],
+    "shell-version": [ "46", "47", "48", "49", "50" ],
     "url": "@PACKAGE_URL@/wiki"
 }


### PR DESCRIPTION
Extension is tested and works well with GNOME 50.