### PR TITLE
Fix handle-method-call signature for GNOME 49 compatibility

### DIFF
--- a/src/service/components/notification.js
+++ b/src/service/components/notification.js
@@ -219,10 +219,26 @@ const Listener = GObject.registerClass({
      *
      * @param {DBus.Interface} iface - The DBus interface
      * @param {string} name - The DBus method name
-     * @param {GLib.Variant} parameters - The method parameters
-     * @param {Gio.DBusMethodInvocation} invocation - The method invocation info
+     * @param {GLib.Variant|Gio.DBusMethodInvocation} param1 - The method parameters or invocation (GNOME 49+ changed order)
+     * @param {Gio.DBusMethodInvocation|GLib.Variant} param2 - The method invocation or parameters (GNOME 49+ changed order)
      */
-    async _onHandleMethodCall(iface, name, parameters, invocation) {
+    async _onHandleMethodCall(iface, name, param1, param2) {
+        let invocation, parameters;
+
+        // GNOME 49+ changed the callback signature from
+        // (iface, name, parameters, invocation) to
+        // (iface, name, invocation, parameters)
+        // Detect which order is being used
+        if (param1 instanceof GLib.Variant) {
+            // Old order: parameters, invocation
+            parameters = param1;
+            invocation = param2;
+        } else {
+            // New order: invocation, parameters
+            invocation = param1;
+            parameters = param2;
+        }
+
         try {
             // Check if notifications are disabled in desktop settings
             if (!this._settings.get_boolean('show-banners'))

--- a/src/service/utils/dbus.js
+++ b/src/service/utils/dbus.js
@@ -111,11 +111,26 @@ export const Interface = GObject.registerClass({
      * @param {Gio.DBusInterfaceInfo} info - The DBus interface
      * @param {Gio.DBusInterface} iface - The DBus interface
      * @param {string} name - The DBus method name
-     * @param {GLib.Variant} parameters - The method parameters
-     * @param {Gio.DBusMethodInvocation} invocation - The method invocation info
+     * @param {GLib.Variant|Gio.DBusMethodInvocation} param1 - The method parameters or invocation (GNOME 49+ changed order)
+     * @param {Gio.DBusMethodInvocation|GLib.Variant} param2 - The method invocation or parameters (GNOME 49+ changed order)
      */
-    async _call(info, iface, name, parameters, invocation) {
+    async _call(info, iface, name, param1, param2) {
         let retval;
+        let invocation, parameters;
+
+        // GNOME 49+ changed the callback signature from
+        // (iface, name, parameters, invocation) to
+        // (iface, name, invocation, parameters)
+        // Detect which order is being used
+        if (param1 instanceof GLib.Variant) {
+            // Old order: parameters, invocation
+            parameters = param1;
+            invocation = param2;
+        } else {
+            // New order: invocation, parameters
+            invocation = param1;
+            parameters = param2;
+        }
 
         // Invoke the instance method
         try {

--- a/src/shell/clipboard.js
+++ b/src/shell/clipboard.js
@@ -137,8 +137,23 @@ export const Clipboard = GObject.registerClass({
         }
     }
 
-    async _onHandleMethodCall(iface, name, parameters, invocation) {
+    async _onHandleMethodCall(iface, name, param1, param2) {
         let retval;
+        let invocation, parameters;
+
+        // GNOME 49+ changed the callback signature from
+        // (iface, name, parameters, invocation) to
+        // (iface, name, invocation, parameters)
+        // Detect which order is being used
+        if (param1 instanceof GLib.Variant) {
+            // Old order: parameters, invocation
+            parameters = param1;
+            invocation = param2;
+        } else {
+            // New order: invocation, parameters
+            invocation = param1;
+            parameters = param2;
+        }
 
         try {
             const args = parameters.recursiveUnpack();

--- a/src/wl_clipboard.js
+++ b/src/wl_clipboard.js
@@ -106,8 +106,23 @@ export const Clipboard = GObject.registerClass(
             }
         }
 
-        async _onHandleMethodCall(iface, name, parameters, invocation) {
+        async _onHandleMethodCall(iface, name, param1, param2) {
             let retval;
+            let invocation, parameters;
+
+            // GNOME 49+ changed the callback signature from
+            // (iface, name, parameters, invocation) to
+            // (iface, name, invocation, parameters)
+            // Detect which order is being used
+            if (param1 instanceof GLib.Variant) {
+                // Old order: parameters, invocation
+                parameters = param1;
+                invocation = param2;
+            } else {
+                // New order: invocation, parameters
+                invocation = param1;
+                parameters = param2;
+            }
 
             try {
                 const args = parameters.recursiveUnpack();


### PR DESCRIPTION
The callback signature for GjsPrivate.DBusImplementation::handle-method-call changed in GNOME 49 from (iface, name, parameters, invocation) to (iface, name, invocation, parameters).
In the current version clipboard not working for gnome 49.

Add runtime detection to support both GNOME 48 and earlier, and GNOME 49+.

Fixes: #2048 (GNOME 49 support)
Affected components:
- shell/clipboard.js
- wl_clipboard.js
- service/utils/dbus.js
- service/components/notification.js