### PR TITLE
Fix DesktopAppInfo loading

### DIFF
--- a/src/service/components/notification.js
+++ b/src/service/components/notification.js
@@ -10,9 +10,10 @@ import GObject from 'gi://GObject';
 import * as DBus from '../utils/dbus.js';
 
 // DesktopAppInfo is no longer in Gio in GNOME 49
-let GioUnix;
-GioUnix = import('gi://GioUnix?version=2.0').catch(() => {
-    GioUnix = Gio;
+const GioUnix = await import('gi://GioUnix?version=2.0').then((imp) => {
+    return imp.default;
+}).catch(() => {
+    return Gio;
 });
 
 

--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -18,9 +18,10 @@ import('gi://GIRepository?version=3.0').catch(() => {
 });
 
 // DesktopAppInfo is no longer in Gio in GNOME 49
-let GioUnix;
-GioUnix = import('gi://GioUnix?version=2.0').catch(() => {
-    GioUnix = Gio;
+const GioUnix = await import('gi://GioUnix?version=2.0').then((imp) => {
+    return imp.default;
+}).catch(() => {
+    return Gio;
 });
 
 import system from 'system';


### PR DESCRIPTION
The conditional import method we were using for GNOME 49 broke with GNOME 50, switch to an alternate method that works with the latest GJS. (Testing is still required to ensure it works with _older_ GJS.)

Fixes #2161