### PR TITLE
fix: prevent empty phone number from hijacking contact lookups

### DIFF
--- a/src/service/components/contacts.js
+++ b/src/service/components/contacts.js
@@ -370,7 +370,8 @@ const Store = GObject.registerClass({
             for (const num of contact.numbers) {
                 const cnumber = num.value.toPhoneNumber();
 
-                if (qnumber.endsWith(cnumber) || cnumber.endsWith(qnumber)) {
+                if ((qnumber !== '' && cnumber !== '' && (qnumber.endsWith(cnumber) || cnumber.endsWith(qnumber))) ||
+                    (qnumber === '' && cnumber === '')) {
                     // If no query name or exact match, return immediately
                     if (!query.name || query.name === contact.name)
                         return contact;


### PR DESCRIPTION
## What
Fix #2176: `toPhoneNumber()` on an all-alphabetic TEL value (e.g. `TEL;TYPE=WORK,PAGER:Amazon`) returns an empty string. In JavaScript `''.endsWith(x)` is always false, but `x.endsWith('')` is always true — so a contact with no digits in its phone number would match every query, and if iterated before the real contact, would return the wrong match.

Guard the `endsWith` shortcut so it only applies when both numbers contain digits. Also preserve the cosmetic empty-vs-empty match (harmless).

## Why
This change resolves the target issue or improvement.

## How to test
Verify that the project builds/runs correctly and the specific bug/improvement is addressed.

Fixes #2176