### PR TITLE
Add ESlint configuration to limit line-length, and correct all newly-flagged issues

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -113,6 +113,18 @@ export default defineConfig([
                 max: 5,
             }],
 
+            '@stylistic/max-len': ['error', {
+                code: 100,
+                comments: 80,
+                ignoreComments: false,
+                ignorePattern: 'TRANSLATORS:',
+                ignoreTrailingComments: false,
+                ignoreRegExpLiterals: true,
+                ignoreStrings: true,
+                ignoreTemplateLiterals: true,
+                ignoreUrls: true,
+            }],
+
             '@stylistic/max-statements-per-line': 'error',
             '@stylistic/new-parens': 'error',
             'no-array-constructor': 'error',

--- a/installed-tests/fixtures/utils.js
+++ b/installed-tests/fixtures/utils.js
@@ -259,7 +259,9 @@ function isolateDirectories() {
  * Patch in the mock components for plugin tests.
  */
 export async function mockComponents() {
-    const {functionOverrides} = await import(`file://${Config.PACKAGE_DATADIR}/service/components/index.js`);
+    const {functionOverrides} = await import(
+        `file://${Config.PACKAGE_DATADIR}/service/components/index.js`
+    );
     const MockComponents = await import('./components/index.js');
 
     functionOverrides.acquire = function (name) {

--- a/installed-tests/suites/components/testClipboardComponent.js
+++ b/installed-tests/suites/components/testClipboardComponent.js
@@ -9,7 +9,9 @@ import Gtk from 'gi://Gtk';
 import GLib from 'gi://GLib';
 
 import Config from '../config.js';
-const {default: Clipboard} = await import(`file://${Config.PACKAGE_DATADIR}/service/components/clipboard.js`);
+const {default: Clipboard} = await import(
+    `file://${Config.PACKAGE_DATADIR}/service/components/clipboard.js`
+);
 
 
 describe('The Clipboard component', function () {
@@ -55,4 +57,3 @@ describe('The Clipboard component', function () {
         clipboard.text = text;
     });
 });
-

--- a/installed-tests/suites/components/testMprisComponent.js
+++ b/installed-tests/suites/components/testMprisComponent.js
@@ -8,7 +8,9 @@ import '../fixtures/utils.js';
 import MockPlayer from '../fixtures/mpris.js';
 
 import Config from '../config.js';
-const {default: Manager} = await import(`file://${Config.PACKAGE_DATADIR}/service/components/mpris.js`);
+const {default: Manager} = await import(
+    `file://${Config.PACKAGE_DATADIR}/service/components/mpris.js`
+);
 
 
 // Prevent auto-loading
@@ -136,4 +138,3 @@ describe('The MPRIS component', function () {
         });
     });
 });
-

--- a/src/extension.js
+++ b/src/extension.js
@@ -367,16 +367,17 @@ export default class GSConnectExtension extends Extension {
         // executable bits from all contents, presumably for security.
         Setup.ensurePermissions();
 
-        // If installed as a user extension, this will install the Desktop entry,
-        // DBus and systemd service files necessary for DBus activation and
-        // GNotifications. Since there's no uninit()/uninstall() hook for extensions
-        // and they're only used *by* GSConnect, they should be okay to leave.
+        // If installed as a user extension, this will install the
+        // Desktop entry, DBus and systemd service files necessary
+        // for DBus activation and GNotifications. Since there's no
+        // uninit()/uninstall() hook for extensions and they're only used
+        // *by* GSConnect, they should be okay to leave.
         Setup.installService();
 
-        // These modify the notification source for GSConnect's GNotifications and
-        // need to be active even when the extension is disabled (eg. lock screen).
-        // Since they *only* affect notifications from GSConnect, it should be okay
-        // to leave them applied.
+        // These modify the notification source for GSConnect's GNotifications
+        // and need to be active even when the extension is disabled
+        // (eg. lock screen). Since they *only* affect notifications
+        // from GSConnect, it should be okay to leave them applied.
         Notification.patchGSConnectNotificationSource();
         Notification.patchGtkNotificationDaemon();
 

--- a/src/service/components/notification.js
+++ b/src/service/components/notification.js
@@ -158,7 +158,8 @@ const Listener = GObject.registerClass({
             const names = await this._listNames();
             names.splice(names.indexOf(sender), 1);
 
-            // Make a short list for substring matches (fractal/org.gnome.Fractal)
+            // Make a short list for substring matches
+            // (fractal/org.gnome.Fractal)
             const appLower = appName.toLowerCase();
 
             const shortList = names.filter(name => {
@@ -219,8 +220,10 @@ const Listener = GObject.registerClass({
      *
      * @param {DBus.Interface} iface - The DBus interface
      * @param {string} name - The DBus method name
-     * @param {GLib.Variant|Gio.DBusMethodInvocation} param1 - The method parameters or invocation (GNOME 50+ changed order)
-     * @param {Gio.DBusMethodInvocation|GLib.Variant} param2 - The method invocation or parameters (GNOME 50+ changed order)
+     * @param {GLib.Variant|Gio.DBusMethodInvocation} param1
+     *        - The method parameters or invocation (GNOME 50+ changed order)
+     * @param {Gio.DBusMethodInvocation|GLib.Variant} param2
+     *        - The method invocation or parameters (GNOME 50+ changed order)
      */
     async _onHandleMethodCall(iface, name, param1, param2) {
         let invocation, parameters;

--- a/src/service/device.js
+++ b/src/service/device.js
@@ -655,7 +655,7 @@ const Device = GObject.registerClass({
         if (this.service === null)
             return;
 
-        // KDE Connect on Android can sometimes give an undefined for params.body
+        // KDE Connect on Android can sometimes give undefined for params.body
         Object.keys(params)
             .forEach(key => params[key] === undefined && delete params[key]);
 

--- a/src/service/init.js
+++ b/src/service/init.js
@@ -14,7 +14,8 @@ import {MissingOpensslError} from '../utils/exceptions.js';
 
 
 // Promise Wrappers
-// We don't use top-level await since it returns control flow to importing module, causing bugs
+// We don't use top-level await since it returns control flow
+// to importing module, causing bugs
 import('gi://EBook').then(({default: EBook}) => {
     Gio._promisify(EBook.BookClient, 'connect');
     Gio._promisify(EBook.BookClient.prototype, 'get_view');
@@ -241,7 +242,8 @@ Gio.File.rm_rf = function (file) {
 /**
  * Extend GLib.Variant with a static method to recursively pack a variant
  *
- * @param {object} [obj] - May be a GLib.Variant, Array, standard Object or literal.
+ * @param {object} [obj]
+ *        - May be a GLib.Variant, Array, standard Object or literal.
  * @returns {GLib.Variant} The resulting GVariant
  */
 function _full_pack(obj) {
@@ -297,7 +299,8 @@ GLib.Variant.full_pack = _full_pack;
 /**
  * Extend GLib.Variant with a method to recursively deepUnpack() a variant
  *
- * @param {object} [obj] - May be a GLib.Variant, Array, standard Object or literal.
+ * @param {object} [obj]
+ *        - May be a GLib.Variant, Array, standard Object or literal.
  * @returns {object} The resulting object
  */
 function _full_unpack(obj) {

--- a/src/service/manager.js
+++ b/src/service/manager.js
@@ -394,8 +394,8 @@ const Manager = GObject.registerClass({
     }
 
     /**
-     * Return a device for {@link packet}, creating it and adding it to the list of
-     * of known devices if it doesn't exist.
+     * Return a device for {@link packet}, creating it and adding it
+     * to the list of of known devices if it doesn't exist.
      *
      * @param {Core.Packet} packet - An identity packet for the device
      * @returns {Device} A device object

--- a/src/service/plugins/mpris.js
+++ b/src/service/plugins/mpris.js
@@ -283,7 +283,7 @@ const MPRISPlugin = GObject.registerClass({
                     loopStatus: player.LoopStatus,
                     shuffle: player.Shuffle,
 
-                    // default values for members that will be filled conditionally
+                    // defaults for members that will be filled conditionally
                     albumArtUrl: '',
                     length: 0,
                     artist: '',

--- a/src/service/plugins/notification.js
+++ b/src/service/plugins/notification.js
@@ -476,7 +476,10 @@ const NotificationPlugin = GObject.registerClass({
             if (!packet.hasPayload())
                 return null;
 
-            // Save the file in the global cache. payloadHash is remote-supplied and used as a filename, so collapse it to a basename to prevent '../' traversal out of the cache dir.
+            // Save the file in the global cache.
+            // payloadHash is remote-supplied and used as a filename,
+            // so collapse it to a basename to prevent '../' traversal
+            // out of the cache dir.
             let payloadHash = GLib.path_get_basename(packet.body.payloadHash || `${Date.now()}`);
             if (!payloadHash || payloadHash === '.' || payloadHash === '..' ||
                 payloadHash.includes('/'))
@@ -732,7 +735,8 @@ const NotificationPlugin = GObject.registerClass({
      */
     copyText(id, text) {
         this._clipboard.text = text;
-        // Since clicking the button closes it on this device, also close it on the remote
+        // Since clicking the button closes it on this device,
+        // also close it on the remote
         this.closeNotification(id);
     }
 });

--- a/src/service/plugins/share.js
+++ b/src/service/plugins/share.js
@@ -130,7 +130,9 @@ const SharePlugin = GObject.registerClass({
     _getFile(filename) {
         const dirpath = this._ensureReceiveDirectory();
 
-        // Remote-supplied filename is untrusted; collapse to a basename so it can't escape the download dir via '../' or an absolute path.
+        // Remote-supplied filename is untrusted;
+        // collapse to a basename so it can't escape the download dir
+        // via '../' or an absolute path.
         let basename = GLib.path_get_basename(filename);
         if (!basename || basename === '.' || basename === '..' ||
             basename.includes('/'))

--- a/src/service/ui/contacts.js
+++ b/src/service/ui/contacts.js
@@ -14,7 +14,8 @@ import system from 'system';
 /**
  * Return a random color
  *
- * @param {string} [salt] - If not %null, will be used as salt for generating a color
+ * @param {string} [salt]
+ *        - If not %null, will be used as salt for generating a color
  * @param {number} alpha - A value in the [0...1] range for the alpha channel
  * @returns {Gdk.RGBA} A new Gdk.RGBA object generated from the input
  */

--- a/src/service/ui/mousepad.js
+++ b/src/service/ui/mousepad.js
@@ -153,10 +153,17 @@ export const InputDialog = GObject.registerClass({
         const keyvalLower = Gdk.keyval_to_lower(event.keyval);
         const realMask = event.state & Gtk.accelerator_get_default_mod_mask();
 
-        this.alt_label.sensitive = !isAlt(keyvalLower) && (realMask & Gdk.ModifierType.MOD1_MASK);
-        this.ctrl_label.sensitive = !isCtrl(keyvalLower) && (realMask & Gdk.ModifierType.CONTROL_MASK);
-        this.shift_label.sensitive = !isShift(keyvalLower) && (realMask & Gdk.ModifierType.SHIFT_MASK);
-        this.super_label.sensitive = !isSuper(keyvalLower) && (realMask & Gdk.ModifierType.SUPER_MASK);
+        this.alt_label.sensitive = !isAlt(keyvalLower) &&
+            (realMask & Gdk.ModifierType.MOD1_MASK);
+
+        this.ctrl_label.sensitive = !isCtrl(keyvalLower) &&
+            (realMask & Gdk.ModifierType.CONTROL_MASK);
+
+        this.shift_label.sensitive = !isShift(keyvalLower) &&
+            (realMask & Gdk.ModifierType.SHIFT_MASK);
+
+        this.super_label.sensitive = !isSuper(keyvalLower) &&
+            (realMask & Gdk.ModifierType.SUPER_MASK);
 
         return super.vfunc_key_release_event(event);
     }
@@ -168,10 +175,17 @@ export const InputDialog = GObject.registerClass({
         let keyvalLower = Gdk.keyval_to_lower(event.keyval);
         let realMask = event.state & Gtk.accelerator_get_default_mod_mask();
 
-        this.alt_label.sensitive = isAlt(keyvalLower) || (realMask & Gdk.ModifierType.MOD1_MASK);
-        this.ctrl_label.sensitive = isCtrl(keyvalLower) || (realMask & Gdk.ModifierType.CONTROL_MASK);
-        this.shift_label.sensitive = isShift(keyvalLower) || (realMask & Gdk.ModifierType.SHIFT_MASK);
-        this.super_label.sensitive = isSuper(keyvalLower) || (realMask & Gdk.ModifierType.SUPER_MASK);
+        this.alt_label.sensitive = isAlt(keyvalLower) ||
+            (realMask & Gdk.ModifierType.MOD1_MASK);
+
+        this.ctrl_label.sensitive = isCtrl(keyvalLower) ||
+            (realMask & Gdk.ModifierType.CONTROL_MASK);
+
+        this.shift_label.sensitive = isShift(keyvalLower) ||
+            (realMask & Gdk.ModifierType.SHIFT_MASK);
+
+        this.super_label.sensitive = isSuper(keyvalLower) ||
+            (realMask & Gdk.ModifierType.SUPER_MASK);
 
         // Wait for a real key before sending
         if (MOD_KEYS.includes(keyvalLower))

--- a/src/service/utils/dbus.js
+++ b/src/service/utils/dbus.js
@@ -111,8 +111,10 @@ export const Interface = GObject.registerClass({
      * @param {Gio.DBusInterfaceInfo} info - The DBus interface
      * @param {Gio.DBusInterface} iface - The DBus interface
      * @param {string} name - The DBus method name
-     * @param {GLib.Variant|Gio.DBusMethodInvocation} param1 - The method parameters or invocation (GNOME 50+ changed order)
-     * @param {Gio.DBusMethodInvocation|GLib.Variant} param2 - The method invocation or parameters (GNOME 50+ changed order)
+     * @param {GLib.Variant|Gio.DBusMethodInvocation} param1
+     *        - The method parameters or invocation (GNOME 50+ changed order)
+     * @param {Gio.DBusMethodInvocation|GLib.Variant} param2
+     *        - The method invocation or parameters (GNOME 50+ changed order)
      */
     async _call(info, iface, name, param1, param2) {
         let retval;

--- a/src/shell/notification.js
+++ b/src/shell/notification.js
@@ -33,7 +33,8 @@ const REPLY_REGEX = new RegExp(/^([^|]+)\|([\s\S]+)\|([0-9a-f]{8}-[0-9a-f]{4}-[1
  * Extracted from notificationDaemon.js, as it's no longer exported
  * https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/notificationDaemon.js#L556
  *
- * @returns {{ 'desktop-startup-id': string }} Object with ID containing current time
+ * @returns {{ 'desktop-startup-id': string }}
+ *          Object with ID containing current time
  */
 function getPlatformData() {
     const startupId = GLib.Variant.new('s', `_TIME${global.get_current_time()}`);
@@ -236,7 +237,13 @@ const Source = GObject.registerClass({
      * GsConnect information
      */
     _createNotification(notification) {
-        const [idMatch, deviceId, requestReplyId, remoteId, localId] = this._parseNotificationId(notification.id);
+        const [
+            idMatch,
+            deviceId,
+            requestReplyId,
+            remoteId,
+            localId,
+        ] = this._parseNotificationId(notification.id);
         const cachedNotification = this._notifications[localId];
 
         // Check if this is a repeat
@@ -321,7 +328,8 @@ const Source = GObject.registerClass({
         notification.connect('notify::acknowledged', () => {
             this.countUpdated();
 
-            // If acknowledged was set to false try to show the notification again
+            // If acknowledged was set to false,
+            // try to show the notification again
             if (!notification.acknowledged)
                 this.emit('notification-request-banner', notification);
         });
@@ -407,10 +415,12 @@ export function unpatchGtkNotificationDaemon() {
  * We patch other Gtk notification sources so we can notify remote devices when
  * notifications have been closed locally.
  */
-const _addNotification = NotificationDaemon.GtkNotificationDaemonAppSource.prototype.addNotification;
+const _addNotification = NotificationDaemon.GtkNotificationDaemonAppSource
+    .prototype.addNotification;
 
 /**
- * Update the prototype for {@link NotificationDaemon.GtkNotificationDaemonAppSource}.
+ * Update the prototype for
+ * {@link NotificationDaemon.GtkNotificationDaemonAppSource}.
  */
 export function patchGtkNotificationSources() {
     // eslint-disable-next-line func-style
@@ -454,14 +464,19 @@ export function patchGtkNotificationSources() {
         );
     };
 
-    NotificationDaemon.GtkNotificationDaemonAppSource.prototype._withdrawGSConnectNotification = _withdrawGSConnectNotification;
+    NotificationDaemon.GtkNotificationDaemonAppSource.prototype
+        ._withdrawGSConnectNotification = _withdrawGSConnectNotification;
 }
 
 
 /**
- * Restore the prototype for {@link NotificationDaemon.GtkNotificationDaemonAppSource}.
+ * Restore the prototype for
+ * {@link NotificationDaemon.GtkNotificationDaemonAppSource}.
  */
 export function unpatchGtkNotificationSources() {
-    NotificationDaemon.GtkNotificationDaemonAppSource.prototype.addNotification = _addNotification;
-    delete NotificationDaemon.GtkNotificationDaemonAppSource.prototype._withdrawGSConnectNotification;
+    NotificationDaemon.GtkNotificationDaemonAppSource.prototype
+        .addNotification = _addNotification;
+
+    delete NotificationDaemon.GtkNotificationDaemonAppSource
+        .prototype._withdrawGSConnectNotification;
 }

--- a/src/utils/setup.js
+++ b/src/utils/setup.js
@@ -226,8 +226,9 @@ export function installService() {
                 _installFile(dirname, manifestFile, contents);
         }
 
-        // Otherwise, if running as a system extension, ensure anything previously
-        // installed when running as a user extension is removed.
+        // Otherwise, if running as a system extension,
+        // ensure anything previously installed when running as a user
+        // extension is removed.
     } else {
         GLib.unlink(GLib.build_filenamev([dbusDir, dbusFile]));
         GLib.unlink(GLib.build_filenamev([appDir, appFile]));

--- a/webextension/js/background.js
+++ b/webextension/js/background.js
@@ -122,7 +122,8 @@ async function forwardPortMessage(message) {
 /**
  * Context Menu Item Callback
  *
- * @param {browser.menus.OnClickData} info - Information about the item and context
+ * @param {browser.menus.OnClickData} info
+ *        - Information about the item and context
  */
 async function onContextItem(info) {
     try {


### PR DESCRIPTION
This PR adds configuration for the `@stylistic/max-len` ESLint plugin, which sets limits on the maximum length of source lines in the codebase. Specifically, the configuration applied is:

```js
{
            '@stylistic/max-len': ['error', {
                code: 100,
                comments: 80,
                ignoreComments: false,
                ignorePattern: 'TRANSLATORS:',
                ignoreTrailingComments: false,
                ignoreRegExpLiterals: true,
                ignoreStrings: true,
                ignoreTemplateLiterals: true,
                ignoreUrls: true,
            }],
```

Which limits source lines to 100 characters, comment lines to 80 characters, and makes all of the exceptions listed there, so that we won't be forced to split long URLs, or strings, or TRANSLATOR: comments, etc.

The second commit corrects all of the newly-flagged errors resulting from running `eslint` with that added configuration.

### Motivation

I noticed some recent changes added excessively-long comment lines, when there's no reason not to wrap comments (in particular) to fit readably in an 80-character width.

But I didn't want to unduly limit our ability to write long string literals, or regular expressions, or URLs, etc. And I didn't want to constrain, or force any changes to, our `TRANSLATOR:` comments. So I made exceptions for all of those.

The worst of the changes this forced were in `src/shell/notification.js`, which has several interactions with the unwieldy-named `NotificationDaemon.GtkNotificationDaemonAppSource` object. So, for example, the diff contains:

```diff
-    NotificationDaemon.GtkNotificationDaemonAppSource.prototype._withdrawGSConnectNotification = _withdrawGSConnectNotification;
+    NotificationDaemon.GtkNotificationDaemonAppSource.prototype
+    ._withdrawGSConnectNotification = _withdrawGSConnectNotification;
```

and

```diff
-    NotificationDaemon.GtkNotificationDaemonAppSource.prototype.addNotification = _addNotification;
-    delete NotificationDaemon.GtkNotificationDaemonAppSource.prototype._withdrawGSConnectNotification;
+    NotificationDaemon.GtkNotificationDaemonAppSource.prototype
+    .addNotification = _addNotification;
+
+    delete NotificationDaemon.GtkNotificationDaemonAppSource
+           .prototype._withdrawGSConnectNotification;
```

I don't _love_ that, but the original source lines really WERE excessively long. And now they're readable in the GitHub web interface, which was part of the intent with this.