### PR TITLE
Fix two issues with the phone number conversion methods, and add tests

### DIFF
--- a/installed-tests/suites/meson.build
+++ b/installed-tests/suites/meson.build
@@ -6,4 +6,4 @@ subdir('core')
 subdir('backends')
 subdir('components')
 subdir('plugins')
-
+subdir('unit')

--- a/installed-tests/suites/unit/meson.build
+++ b/installed-tests/suites/unit/meson.build
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: GSConnect Developers https://github.com/GSConnect
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+unit_tests_execdir = join_paths(installed_tests_execdir, 'unit')
+unit_tests_metadir = join_paths(installed_tests_metadir, 'unit')
+
+# unit Suites
+unit_tests = [
+  'PhoneNumber',
+]
+
+
+foreach test : unit_tests
+  test_file = files('test@0@.js'.format(test))
+
+  test(test, minijasmine,
+        args: [test_file],
+     depends: [installed_tests_prepared],
+         env: test_env,
+    protocol: 'tap',
+       suite: 'unit'
+  )
+
+  if get_option('installed_tests')
+    test_config = configuration_data()
+    test_config.set('jasmine_path', minijasmine_path)
+    test_config.set('name', 'test@0@.js'.format(test))
+    test_config.set('installed_tests_execdir', unit_tests_execdir)
+
+    test_description = configure_file(
+      configuration: test_config,
+              input: join_paths(installed_tests_srcdir, 'jasmine.test.in'),
+             output: 'test@0@.test'.format(test),
+        install_dir: unit_tests_metadir,
+    )
+
+    install_data(test_file,
+      install_dir: unit_tests_execdir,
+    )
+  endif
+endforeach
+

--- a/installed-tests/suites/unit/testPhoneNumber.js
+++ b/installed-tests/suites/unit/testPhoneNumber.js
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: GSConnect Developers https://github.com/GSConnect
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import Config from '../config.js';
+
+// eslint-disable-next-line no-unused-vars
+const {default: Service} = await import(`file://${Config.PACKAGE_DATADIR}/service/init.js`);
+
+
+describe('A patched String definition', function () {
+
+    it('has phone Number methods', function () {
+        const aNumber = '+1 (212) 555-1212';
+
+        expect(aNumber.toPhoneNumber).toBeDefined();
+        expect(aNumber.equalsPhoneNumber).toBeDefined();
+    });
+
+    it('can clean up numbers with toPhoneNumber', function () {
+        expect('+1 (212) 555-1212'.toPhoneNumber()).toBe('12125551212');
+        expect('1-212-555-1212'.toPhoneNumber()).toBe('12125551212');
+        expect('+01 212 555 1212'.toPhoneNumber()).toBe('12125551212');
+        expect(''.toPhoneNumber()).toBe('');
+        expect('CALL-GNOME'.toPhoneNumber()).toBe('CALLGNOME');
+    });
+
+    it('can compare numbers with equalsPhoneNumber', function () {
+        const aNumber = '+1 (212) 555-1212';
+        const bNumber = '+01 212 555 1212';
+        const cNumber = '555-1212';
+        const badNumber = 'CALL-GNOME';
+        const emptyNumber = '';
+
+        expect(aNumber.equalsPhoneNumber(bNumber)).toBeTrue();
+        expect(aNumber.equalsPhoneNumber(cNumber)).toBeTrue();
+        expect(bNumber.equalsPhoneNumber(cNumber)).toBeTrue();
+
+        expect(aNumber.equalsPhoneNumber(badNumber)).toBeFalse();
+        expect(aNumber.equalsPhoneNumber(emptyNumber)).toBeFalse();
+
+        expect(badNumber.equalsPhoneNumber(emptyNumber)).toBeFalse();
+    });
+});

--- a/src/service/init.js
+++ b/src/service/init.js
@@ -181,7 +181,7 @@ if (!globalThis.HAVE_GNOME) {
  * @returns {string} Return the string stripped of leading 0, and ' ()-+'
  */
 String.prototype.toPhoneNumber = function () {
-    const strippedNumber = this.replace(/^0*|[ ()+-]/g, '');
+    const strippedNumber = this.replace(/[ ()+-]/g, '').replace(/^0*/, '');
 
     if (strippedNumber.length)
         return strippedNumber;
@@ -200,7 +200,7 @@ String.prototype.equalsPhoneNumber = function (number) {
     const a = this.toPhoneNumber();
     const b = number.toPhoneNumber();
 
-    return (a.length && b.length && (a.endsWith(b) || b.endsWith(a)));
+    return Boolean(a.length && b.length && (a.endsWith(b) || b.endsWith(a)));
 };
 
 


### PR DESCRIPTION
This PR contains a set of tests, and two fixes, for the phone-number conversion methods we monkeypatch into `String.prototype`.

The first commit adds a new Jasmine suite, `unit`, containing `testPhoneNumber.js`, which tests those methods in isolation.

The second commit fixes both issues that would otherwise cause those tests to fail:

1. `String.prototype.toPhoneNumber()` was using a bad regex to clean up phone numbers, such that a number like `+1 (212) 555-1212` would come out as `+12125551212`, and `+01-212-555-1212` would come out as `+012125551212`. Fixed by replacing with a chained double `.replace()` that holds off stripping leading zeroes until AFTER all of the other unwanted characters are cleaned up.

2. `String.prototype.equalsPhoneNumber()` was returning the result of some comparisons directly, in a way that caused the function to return `0` for some failure cases. Wrapped the return value in a `Boolean()` to ensure that it's always exactly `true` or `false`, as specified in the jsdoc metadata.