### PR TITLE
lan: fix IPv6 address parsing and formatting

### DIFF
--- a/installed-tests/suites/backends/testLanBackend.js
+++ b/installed-tests/suites/backends/testLanBackend.js
@@ -145,3 +145,93 @@ describe('A LAN channel service', function () {
     // TODO: restarting stopped services
 });
 
+
+describe('LAN address formatting', function () {
+    it('leaves IPv4 addresses unbracketed', function () {
+        expect(Lan._formatAddress('192.168.1.10', 1716))
+            .toBe('lan://192.168.1.10:1716');
+    });
+
+    it('brackets IPv6 addresses', function () {
+        expect(Lan._formatAddress('2001:db8::1', 1716))
+            .toBe('lan://[2001:db8::1]:1716');
+    });
+
+    it('brackets IPv6 addresses carrying a zone', function () {
+        expect(Lan._formatAddress('fe80::1%wlan0', 1716))
+            .toBe('lan://[fe80::1%wlan0]:1716');
+    });
+});
+
+
+describe('LAN address parsing', function () {
+    it('parses an IPv4 address with a port', function () {
+        const addr = Lan._parseSocketAddress('192.168.1.10:1716', 1716);
+
+        expect(addr).not.toBeNull();
+        expect(addr.address.to_string()).toBe('192.168.1.10');
+        expect(addr.port).toBe(1716);
+    });
+
+    it('falls back to the default port', function () {
+        const addr = Lan._parseSocketAddress('192.168.1.10', 1716);
+
+        expect(addr).not.toBeNull();
+        expect(addr.port).toBe(1716);
+    });
+
+    it('parses a bracketed IPv6 address with a port', function () {
+        const addr = Lan._parseSocketAddress('[2001:db8::1]:1739', 1716);
+
+        expect(addr).not.toBeNull();
+        expect(addr.address.to_string()).toBe('2001:db8::1');
+        expect(addr.port).toBe(1739);
+    });
+
+    it('parses a bracketed IPv6 address without a port', function () {
+        const addr = Lan._parseSocketAddress('[2001:db8::1]', 1716);
+
+        expect(addr).not.toBeNull();
+        expect(addr.address.to_string()).toBe('2001:db8::1');
+        expect(addr.port).toBe(1716);
+    });
+
+    // Earlier versions stored IPv6 addresses unbracketed in `last-connection`
+    it('parses a bare IPv6 address', function () {
+        const addr = Lan._parseSocketAddress('2001:db8::1', 1716);
+
+        expect(addr).not.toBeNull();
+        expect(addr.address.to_string()).toBe('2001:db8::1');
+        expect(addr.port).toBe(1716);
+    });
+
+    it('round-trips a formatted IPv6 address', function () {
+        const uri = Lan._formatAddress('2001:db8::1', 1716);
+        const addr = Lan._parseSocketAddress(uri.replace('lan://', ''), 1716);
+
+        expect(addr).not.toBeNull();
+        expect(addr.address.to_string()).toBe('2001:db8::1');
+        expect(addr.port).toBe(1716);
+    });
+
+    it('parses an IPv6 address carrying a zone', function () {
+        const addr = Lan._parseSocketAddress('[fe80::1%lo]:1716', 1716);
+
+        expect(addr).not.toBeNull();
+        expect(addr.address.to_string()).toBe('fe80::1');
+        expect(addr.port).toBe(1716);
+    });
+
+    it('tolerates an unresolvable zone', function () {
+        const addr = Lan._parseSocketAddress('[fe80::1%nosuchiface0]:1716', 1716);
+
+        expect(addr).not.toBeNull();
+        expect(addr.address.to_string()).toBe('fe80::1');
+        expect(addr.scope_id).toBe(0);
+    });
+
+    it('returns null for an unparseable address', function () {
+        expect(Lan._parseSocketAddress('not-an-address', 1716)).toBeNull();
+    });
+});
+

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -78,6 +78,104 @@ export function _configureSocket(connection) {
 
 
 /**
+ * Resolve a network interface name to its index, for use as an IPv6 scope id.
+ *
+ * GJS exposes no binding for if_nametoindex(), so this reads sysfs. Returns 0
+ * (ie. no scope) on platforms without sysfs, which is correct for every address
+ * except link-local ones.
+ *
+ * @param {string} name - An interface name, eg. "wlan0"
+ * @returns {number} The interface index, or 0 if it could not be resolved
+ */
+export function _interfaceIndex(name) {
+    try {
+        const [ok, bytes] = GLib.file_get_contents(
+            `/sys/class/net/${name}/ifindex`);
+
+        if (ok)
+            return parseInt(new TextDecoder().decode(bytes).trim()) || 0;
+    } catch {
+        // Unknown interface, or no sysfs
+    }
+
+    return 0;
+}
+
+
+/**
+ * Format a host and port as a `lan://` URI, bracketing IPv6 literals so that
+ * the result can be parsed back unambiguously.
+ *
+ * @param {string} host - A hostname or IP address
+ * @param {number} port - A port number
+ * @returns {string} A `lan://` URI
+ */
+export function _formatAddress(host, port) {
+    if (typeof host === 'string' && host.includes(':'))
+        return `lan://[${host}]:${port}`;
+
+    return `lan://${host}:${port}`;
+}
+
+
+/**
+ * Parse a `<host>:<port>` string into a Gio.InetSocketAddress.
+ *
+ * Accepts a bracketed IPv6 literal with an optional zone (`[fe80::1%wlan0]:1716`)
+ * as well as the plain IPv4 form. Bare IPv6 literals are also accepted, since
+ * earlier versions stored them unbracketed in the `last-connection` setting.
+ *
+ * @param {string} address - The address to parse
+ * @param {number} defaultPort - The port to use if the address omits one
+ * @returns {?Gio.InetSocketAddress} A socket address, or %null if unparseable
+ */
+export function _parseSocketAddress(address, defaultPort) {
+    let host = address;
+    let portstr;
+    let scopeId = 0;
+
+    const bracketed = address.match(/^\[([^\]]+)\](?::(\d+))?$/);
+
+    if (bracketed !== null) {
+        host = bracketed[1];
+        portstr = bracketed[2];
+
+    // More than one colon means an IPv6 literal. It may or may not have a
+    // trailing port, and without brackets that is genuinely ambiguous, so
+    // prefer the reading where the whole string is an address.
+    } else if (address.indexOf(':') !== address.lastIndexOf(':')) {
+        if (Gio.InetAddress.new_from_string(address) === null) {
+            const sep = address.lastIndexOf(':');
+            host = address.slice(0, sep);
+            portstr = address.slice(sep + 1);
+        }
+
+    } else {
+        [host, portstr] = address.split(':');
+    }
+
+    // Split off a zone ("%wlan0"); link-local addresses are unusable without it
+    const zone = host.indexOf('%');
+
+    if (zone !== -1) {
+        scopeId = _interfaceIndex(host.slice(zone + 1));
+        host = host.slice(0, zone);
+    }
+
+    const inetAddress = Gio.InetAddress.new_from_string(host);
+
+    if (inetAddress === null)
+        return null;
+
+    return new Gio.InetSocketAddress({
+        address: inetAddress,
+        port: parseInt(portstr) || defaultPort,
+        scope_id: scopeId,
+    });
+}
+
+
+/**
  * Lan.ChannelService consists of two parts:
  *
  * The TCP Listener listens on a port and constructs a Channel object from the
@@ -422,12 +520,9 @@ export const ChannelService = GObject.registerClass({
             if (!this._networkAvailable)
                 return;
 
-            // Try to parse strings as <host>:<port>
-            if (typeof address === 'string') {
-                const [host, portstr] = address.split(':');
-                const port = parseInt(portstr) || this.port;
-                address = Gio.InetSocketAddress.new_from_string(host, port);
-            }
+            // Try to parse strings as <host>:<port>, including bracketed IPv6
+            if (typeof address === 'string')
+                address = _parseSocketAddress(address, this.port);
 
             // If we succeed, remember this host
             if (address instanceof Gio.InetSocketAddress) {
@@ -439,12 +534,19 @@ export const ChannelService = GObject.registerClass({
                 address = this._udp_address;
             }
 
-            // Broadcast on each open socket
-            if (this._udp6 !== null)
-                this._udp6.send_to(address, this.identity.serialize(), null);
+            // Send on a socket that can carry this address family. Note that
+            // when the IPv6 socket is dual-stack _initUdpListener() leaves
+            // _udp4 as null, so IPv4 targets fall through to it.
+            if (address.address.family === Gio.SocketFamily.IPV6) {
+                if (this._udp6 !== null)
+                    this._udp6.send_to(address, this.identity.serialize(), null);
 
-            if (this._udp4 !== null)
+            } else if (this._udp4 !== null) {
                 this._udp4.send_to(address, this.identity.serialize(), null);
+
+            } else if (this._udp6 !== null) {
+                this._udp6.send_to(address, this.identity.serialize(), null);
+            }
         } catch (e) {
             debug(e, address);
         }
@@ -552,7 +654,7 @@ export const Channel = GObject.registerClass({
     }
 
     get address() {
-        return `lan://${this.host}:${this.port}`;
+        return _formatAddress(this.host, this.port);
     }
 
     get certificate() {

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -121,9 +121,10 @@ export function _formatAddress(host, port) {
 /**
  * Parse a `<host>:<port>` string into a Gio.InetSocketAddress.
  *
- * Accepts a bracketed IPv6 literal with an optional zone (`[fe80::1%wlan0]:1716`)
- * as well as the plain IPv4 form. Bare IPv6 literals are also accepted, since
- * earlier versions stored them unbracketed in the `last-connection` setting.
+ * Accepts a bracketed IPv6 literal with an optional zone
+ * (`[fe80::1%wlan0]:1716`) as well as the plain IPv4 form.
+ * Bare IPv6 literals are also accepted, since earlier versions
+ * stored them unbracketed in the `last-connection` setting.
  *
  * @param {string} address - The address to parse
  * @param {number} defaultPort - The port to use if the address omits one


### PR DESCRIPTION

Hey,

This fixes the two IPv6 address-handling bugs I wrote up in #2185.

Quick recap of what was wrong:

- `broadcast()` parsed `<host>:<port>` with `address.split(':')`, which splits on the first
  colon and so shreds any IPv6 literal — `fe80::1:1716` comes out as host `fe80`.
- `Channel.address` built `lan://${this.host}:${this.port}` with no brackets, so IPv6
  addresses were emitted in an unparseable form.

Those compound, because the value round-trips through GSettings (`device.js:279` writes
`channel.address` into `last-connection`, `manager.js:465` feeds it back to `identify()`).
The net effect is that GSConnect never reconnects directly to an IPv6 peer — the parse
returns null, the `instanceof` check fails, and it quietly falls back to a 255.255.255.255
broadcast with no warning.

What's in here:

- `_formatAddress()` brackets IPv6 hosts.
- `_parseSocketAddress()` handles `[addr]:port`, `[addr%zone]:port`, the plain IPv4 form, and
  bare IPv6 literals — the last one so that values already written unbracketed into
  `last-connection` by earlier versions still parse after upgrading.
- A zone is resolved to a `scope_id` by reading `/sys/class/net/<iface>/ifindex`, since GJS
  exposes no `if_nametoindex()` and `Gio.InetSocketAddress.new_from_string()` has no
  parameter for it. Returns 0 where there's no sysfs, which is correct for everything except
  link-local addresses.
- `broadcast()` now sends on a socket that can carry the address family. Worth a look during
  review: when `_udp6.speaks_ipv4()` is true, `_initUdpListener()` deliberately leaves
  `_udp4` as null, so IPv4 targets have to fall through to `_udp6`. The naive version of this
  change silently breaks all IPv4 broadcast.

No protocol changes — this only touches how addresses are stringified and parsed locally, so
it shouldn't have any KDE Connect compatibility implications.

Added 12 tests to `testLanBackend.js` covering formatting, parsing, zones, round-tripping and
the unparseable case. All pass.

Verified end to end as well, not just in unit tests. With the patch running I triggered a
directed identify at an Android peer's link-local address over a Bluetooth PAN link:

- the identity packet goes out over IPv6 (`fe80::…6d41b > fe80::…a86a … UDP, length 1778`,
  fragmented, which is worth knowing if you go looking for it — a `port 1716` capture filter
  won't match the fragments)
- the peer connects back and the channel is established
- `Channel.address` now yields `lan://[fe80::de6a:e7ff:fe1e:a86a]:1716`
- that gets written to `last-connection` in a form that parses back correctly, which is the
  round-trip that was broken

Heads up for anyone testing an upgrade path: once the fixed getter has written a bracketed
address into `last-connection`, downgrading to an unpatched version leaves a value it can't
parse. The reverse direction is handled — the bare-IPv6 branch in `_parseSocketAddress()`
exists so old unbracketed values still work after upgrading.

One thing to flag honestly: the 7 pre-existing `A LAN channel service` tests fail in my
environment, but they fail identically on a clean checkout with none of my changes applied,
so I don't believe they're related. Would appreciate a second pair of eyes on that.

Tested on GSConnect v72, GNOME Shell 50.1, gjs 1.88.0, Ubuntu 26.04, Wayland. ESLint clean.
