### PR TITLE
Fix 'shortucts' typo error to 'shortcuts'

### DIFF
--- a/data/ui/preferences-shortcut-editor.ui
+++ b/data/ui/preferences-shortcut-editor.ui
@@ -56,7 +56,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
             <property name="can_focus">False</property>
             <property name="halign">center</property>
             <property name="hexpand">True</property>
-            <property name="label" translatable="yes">Note that you have to first disable any conflicting shortucts in GNOME Settings.</property>
+            <property name="label" translatable="yes">Note that you have to first disable any conflicting shortcuts in GNOME Settings.</property>
             <property name="visible">True</property>
           </object>
           <packing>


### PR DESCRIPTION
Hi!
I saw in the last commit that a typo error has been introduced: so here is the fix!