### PR TITLE
Phone number comparisons: Use .equalsPhoneNumber

### DIFF
--- a/src/service/components/contacts.js
+++ b/src/service/components/contacts.js
@@ -362,15 +362,12 @@ const Store = GObject.registerClass({
         // First look for an existing contact by number
         const contacts = this.contacts;
         const matches = [];
-        const qnumber = query.number.toPhoneNumber();
 
         for (let i = 0, len = contacts.length; i < len; i++) {
             const contact = contacts[i];
 
             for (const num of contact.numbers) {
-                const cnumber = num.value.toPhoneNumber();
-
-                if (qnumber.endsWith(cnumber) || cnumber.endsWith(qnumber)) {
+                if (query.number.equalsPhoneNumber(num.value)) {
                     // If no query name or exact match, return immediately
                     if (!query.name || query.name === contact.name)
                         return contact;

--- a/src/service/plugins/sms.js
+++ b/src/service/plugins/sms.js
@@ -493,15 +493,10 @@ const SMSPlugin = GObject.registerClass({
     }
 
     _threadHasAddress(thread, addressObj) {
-        const number = addressObj.address.toPhoneNumber();
-
         for (const taddressObj of thread[0].addresses) {
-            const tnumber = taddressObj.address.toPhoneNumber();
-
-            if (number.endsWith(tnumber) || tnumber.endsWith(number))
+            if (addressObj.address?.equalsPhoneNumber(taddressObj.address))
                 return true;
         }
-
         return false;
     }
 

--- a/src/service/ui/contacts.js
+++ b/src/service/ui/contacts.js
@@ -167,15 +167,10 @@ function getNumberTypeLabel(type) {
  * @returns {string} A (possibly) better display number for the address
  */
 export function getDisplayNumber(contact, address) {
-    const number = address.toPhoneNumber();
-
     for (const contactNumber of contact.numbers) {
-        const cnumber = contactNumber.value.toPhoneNumber();
-
-        if (number.endsWith(cnumber) || cnumber.endsWith(number))
+        if (address?.equalsPhoneNumber(contactNumber.value))
             return GLib.markup_escape_text(contactNumber.value, -1);
     }
-
     return GLib.markup_escape_text(address, -1);
 }
 

--- a/src/service/ui/messaging.js
+++ b/src/service/ui/messaging.js
@@ -389,9 +389,7 @@ const Conversation = GObject.registerClass({
                 continue;
 
             for (const contactNumber of contact.numbers) {
-                const cnumber = contactNumber.value.toPhoneNumber();
-
-                if (cnumber && (number.endsWith(cnumber) || cnumber.endsWith(number))) {
+                if (number.equalsPhoneNumber(contactNumber.value)) {
                     number = contactNumber.value;
                     break;
                 }
@@ -1147,15 +1145,10 @@ export const Window = GObject.registerClass({
     }
 
     _includesAddress(addresses, addressObj) {
-        const number = addressObj.address.toPhoneNumber();
-
         for (const haystackObj of addresses) {
-            const tnumber = haystackObj.address.toPhoneNumber();
-
-            if (number.endsWith(tnumber) || tnumber.endsWith(number))
+            if (addressObj.address.equalsPhoneNumber(haystackObj.address))
                 return true;
         }
-
         return false;
     }
 


### PR DESCRIPTION
Now that `String.prototype.equalsPhoneNumber()` is fixed to perform comparisons the way we want, replace all of the ad-hoc comparison code with calls to `.equalsPhoneNumber()`. This eliminates a lot of explicit temporary `.toPhoneNumber()` creation (because it's implicit in the call to `.equalsPhoneNumber()`), and it means that comparisons are automatically protected from matching when one side is empty (since `.equalsPhoneNumber()` always checks for that condition).

Along the way, add a few `?.` property accesses to better protect against possible null dereferences.

Fixes #2176