### PR TITLE
notification: suppress duplicate re-sends from reconnecting devices

### DIFF
--- a/installed-tests/suites/plugins/testNotificationPlugin.js
+++ b/installed-tests/suites/plugins/testNotificationPlugin.js
@@ -281,6 +281,12 @@ describe('The notification plugin', function () {
     });
 
     describe('suppresses duplicate re-sends', function () {
+        beforeEach(function () {
+            // Simulate a just-reconnected device so the suppression
+            // burst window is active
+            remotePlugin._lastConnectedAt = Date.now();
+        });
+
         it('shows a notification only once when re-sent identically',
             async function () {
                 const packet = {
@@ -308,6 +314,24 @@ describe('The notification plugin', function () {
                 expect(remotePlugin.device.showNotification.calls.count()).toBe(1);
 
                 packet.body = {...Notifications.withoutIcon, text: 'Changed Body'};
+
+                await remotePlugin._receiveNotification(packet);
+                expect(remotePlugin.device.showNotification.calls.count()).toBe(2);
+            });
+
+        it('does not suppress re-sends outside the reconnection burst',
+            async function () {
+                const packet = {
+                    type: 'kdeconnect.notification',
+                    body: Notifications.withoutIcon,
+                };
+
+                await remotePlugin._receiveNotification(packet);
+                expect(remotePlugin.device.showNotification.calls.count()).toBe(1);
+
+                // The burst window has elapsed; the same notification is a
+                // new event now and must be shown again
+                remotePlugin._lastConnectedAt = Date.now() - (60 * 1000 + 1000);
 
                 await remotePlugin._receiveNotification(packet);
                 expect(remotePlugin.device.showNotification.calls.count()).toBe(2);

--- a/installed-tests/suites/plugins/testNotificationPlugin.js
+++ b/installed-tests/suites/plugins/testNotificationPlugin.js
@@ -280,6 +280,40 @@ describe('The notification plugin', function () {
         expect(remotePlugin._handleNotificationRequest).toHaveBeenCalled();
     });
 
+    describe('suppresses duplicate re-sends', function () {
+        it('shows a notification only once when re-sent identically',
+            async function () {
+                const packet = {
+                    type: 'kdeconnect.notification',
+                    body: Notifications.withoutIcon,
+                };
+
+                await remotePlugin._receiveNotification(packet);
+                expect(remotePlugin.device.showNotification.calls.count()).toBe(1);
+
+                // A re-send of the same notification (e.g. after the remote
+                // service restarts and reconnects) is suppressed
+                await remotePlugin._receiveNotification(packet);
+                expect(remotePlugin.device.showNotification.calls.count()).toBe(1);
+            });
+
+        it('shows a notification again if its content changed',
+            async function () {
+                const packet = {
+                    type: 'kdeconnect.notification',
+                    body: Notifications.withoutIcon,
+                };
+
+                await remotePlugin._receiveNotification(packet);
+                expect(remotePlugin.device.showNotification.calls.count()).toBe(1);
+
+                packet.body = {...Notifications.withoutIcon, text: 'Changed Body'};
+
+                await remotePlugin._receiveNotification(packet);
+                expect(remotePlugin.device.showNotification.calls.count()).toBe(2);
+            });
+    });
+
     it('disables its GActions when disconnected', function () {
         testRig.setConnected(false);
 

--- a/src/service/plugins/notification.js
+++ b/src/service/plugins/notification.js
@@ -129,6 +129,15 @@ function _isSmsNotification(packet) {
 }
 
 
+// A cache of recently received notifications, used to suppress duplicate
+// re-sends. When a remote device's service restarts or reconnects (e.g.
+// after the OS kills its background service), it re-sends its complete
+// list of active notifications, causing the same notifications to be
+// shown repeatedly on this device.
+const RECENT_NOTIFICATION_TTL = 30 * 60 * 1000;
+const RECENT_NOTIFICATION_MAX = 200;
+
+
 /**
  * Remove a local libnotify or Gtk notification.
  *
@@ -192,6 +201,8 @@ const NotificationPlugin = GObject.registerClass({
         );
         this._onApplicationsChanged(this.settings, 'applications');
         this._applicationsChangedSkip = false;
+
+        this._recentNotifications = new Map();
     }
 
     connected() {
@@ -520,12 +531,66 @@ const NotificationPlugin = GObject.registerClass({
     }
 
     /**
+     * Check if a notification packet is a duplicate of one received
+     * recently, and update the cache.
+     *
+     * @param {Core.Packet} packet - A `kdeconnect.notification`
+     * @returns {boolean} Whether the notification was recently received
+     */
+    _isRecentNotification(packet) {
+        const body = packet.body;
+        const key = [
+            body.id,
+            body.appName,
+            body.title,
+            body.text,
+            body.requestReplyId,
+        ].join('\u0000');
+
+        const now = Date.now();
+
+        const timestamp = this._recentNotifications.get(key);
+
+        // A duplicate re-send; refresh the timestamp so the suppression
+        // window continues to cover the remote device's reconnect cadence
+        if (timestamp !== undefined && now - timestamp <= RECENT_NOTIFICATION_TTL) {
+            this._recentNotifications.set(key, now);
+            debug(`Suppressing duplicate notification: ${body.appName}: ${body.title}`);
+            return true;
+        }
+
+        // Remove expired entries
+        for (const [k, ts] of this._recentNotifications) {
+            if (now - ts > RECENT_NOTIFICATION_TTL)
+                this._recentNotifications.delete(k);
+        }
+
+        // Evict the oldest entries if the cache is too large
+        while (this._recentNotifications.size >= RECENT_NOTIFICATION_MAX) {
+            this._recentNotifications.delete(
+                this._recentNotifications.keys().next().value
+            );
+        }
+
+        this._recentNotifications.set(key, now);
+
+        return false;
+    }
+
+    /**
      * Receive an incoming notification.
      *
      * @param {Core.Packet} packet - A `kdeconnect.notification`
      */
     async _receiveNotification(packet) {
         try {
+            // Ignore duplicate re-sends of a notification we've recently
+            // shown; the remote device re-sends its full list of active
+            // notifications whenever its service restarts or the connection
+            // drops and reconnects
+            if (this._isRecentNotification(packet))
+                return;
+
             // Set defaults
             let action = null;
             let buttons = [];

--- a/src/service/plugins/notification.js
+++ b/src/service/plugins/notification.js
@@ -137,6 +137,12 @@ function _isSmsNotification(packet) {
 const RECENT_NOTIFICATION_TTL = 30 * 60 * 1000;
 const RECENT_NOTIFICATION_MAX = 200;
 
+// Only suppress duplicate re-sends which arrive shortly after a device
+// (re)connection; the remote service re-sends its full notification list
+// as part of the reconnection handshake. Notifications re-posted while
+// the connection is stable are considered new and are never suppressed.
+const RECENT_NOTIFICATION_BURST_WINDOW = 60 * 1000;
+
 
 /**
  * Remove a local libnotify or Gtk notification.
@@ -203,10 +209,13 @@ const NotificationPlugin = GObject.registerClass({
         this._applicationsChangedSkip = false;
 
         this._recentNotifications = new Map();
+        this._lastConnectedAt = 0;
     }
 
     connected() {
         super.connected();
+
+        this._lastConnectedAt = Date.now();
 
         this._requestNotifications();
     }
@@ -553,7 +562,9 @@ const NotificationPlugin = GObject.registerClass({
 
         // A duplicate re-send; refresh the timestamp so the suppression
         // window continues to cover the remote device's reconnect cadence
-        if (timestamp !== undefined && now - timestamp <= RECENT_NOTIFICATION_TTL) {
+        if (timestamp !== undefined &&
+            now - timestamp <= RECENT_NOTIFICATION_TTL &&
+            now - this._lastConnectedAt <= RECENT_NOTIFICATION_BURST_WINDOW) {
             this._recentNotifications.set(key, now);
             debug(`Suppressing duplicate notification: ${body.appName}: ${body.title}`);
             return true;


### PR DESCRIPTION
## Summary

Mobile OSes with aggressive battery management (ColorOS, MIUI, etc.) regularly kill background services. When GSConnect's service on the phone is killed and restarts (or the connection drops and reconnects), the device re-sends its **complete list of active notifications** — so the same notifications keep re-appearing on the desktop over and over, even if they were already shown (or dismissed).

This adds a small cache to the notification plugin that suppresses these re-send bursts **only during the reconnection handshake**, so legitimate notifications are never swallowed.

## Changes

- `src/service/plugins/notification.js`
  - Per-plugin `_recentNotifications` Map (initialized in `_init`), keyed by the packet's `id` + `appName` + `title` + `text` + `requestReplyId`
  - `connected()` records `_lastConnectedAt`; `_isRecentNotification()` only treats a re-send as a duplicate if it arrives within `RECENT_NOTIFICATION_BURST_WINDOW` (60s) of a (re)connection
  - `RECENT_NOTIFICATION_TTL` (30 min) and `RECENT_NOTIFICATION_MAX` (200) bound cache size; expired entries are purged and oldest entries evicted
  - `debug()` line when a duplicate is suppressed (gated by the existing `debug` setting)
- `installed-tests/suites/plugins/testNotificationPlugin.js`
  - Three new cases: identical re-send inside the burst window is suppressed; changed content is shown again; identical re-send **outside** the burst window is shown again

## Design notes

**Why is `id` part of the key?** On Android, notification IDs are assigned by the *source app*, not by GSConnect's relay, so they are stable across GSConnect service restarts — the reconnect re-send carries the same `id`, which is exactly what gets deduped. Including `id` deliberately means a genuinely **new** notification instance with identical content (a recurring alarm, an app that re-posts the same text) is still shown: the key only collapses re-sends of the *same instance*.

**Why gate on the reconnection burst rather than a bare TTL?** The desktop uses the packet `id` as the Gio notification ID, so same-ID re-sends are normally collapsed by the Shell — but that breaks when (a) the user has dismissed the notification (a re-send re-pops it), or (b) the Shell's in-place update doesn't apply. Content-keying alone risks suppressing *legitimate* repeats (recurring alarms, repeated reminders) within the window. Restricting suppression to the 60s following a (re)connection means:

- the reconnect-burst spam (the actual bug) is silenced,
- a notification re-posted while the connection is stable is always shown,
- the "refresh on suppression" behavior only extends across actual reconnect churn — once the device stays connected, the window closes and nothing is hidden.

`RECENT_NOTIFICATION_TTL` is now purely a memory bound for the cache, not a behavioral window, so it is intentionally not exposed as a setting; happy to add one if maintainers prefer.

## Verification

- The jasmine suite in this PR covers the behavior; CI runs ESLint and the full installed-tests suite
- Logic additionally exercised during development with a standalone 45-assertion harness (TTL expiry, eviction, reply-ID variants, burst-window boundaries, reconnect-churn refresh); not part of the repo
- Live reproduction on a ColorOS device (realme GT 7T): after patching the extension and toggling airplane mode, a reconnect burst of 17 re-sent notifications (Facebook, Discord, Notion Calendar, ChatGPT, Telegram, ...) was suppressed in the journal; the first cycle was shown as expected
